### PR TITLE
Bunch of small fixes and improvements

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -47,8 +47,6 @@
 "WW.Defense.Armored": "Armored Defense",
 "WW.Defense.Details": "(armor, if any, shield, if any)",
 
-"WW.Dialog.Cancel": "Cancel",
-
 "WW.Health.Label": "Health",
 "WW.Health.Normal": "Normal Health Score",
 "WW.Health.Current": "Current Health Score",

--- a/lang/en.json
+++ b/lang/en.json
@@ -675,6 +675,8 @@
 
 "WW.Settings.Combat.SkipActed": "Skip Acted?",
 "WW.Settings.Combat.SkipActedHint": "Automatically bypass combatants who already acted during this round.",
+"WW.Settings.DamageBarReverse": "Reverse Damage Bars",
+"WW.Settings.DamageBarReverseHint": "If enabled, health/damage bars start full and decrease when taking damage. If disabled, bars start at 0, filling as damage increases.",
 
 "WW.System.Help": "Help",
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -653,13 +653,12 @@
 "WW.Combat.Phase.End": "End of the Round",
 
 "WW.Combat.Turn.Label": "Take a Regular Turn",
-"WW.Combat.Turn.Msg": "is taking a regular turn",
+"WW.Combat.Turn.Msg": "{name} is taking a regular turn.",
 
 "WW.Combat.Initiative.Label": "Take The Initiative",
-"WW.Combat.Initiative.ChatMsg": "is taking the initiative",
+"WW.Combat.Initiative.ChatMsg": "{name} is taking the initiative.",
 "WW.Combat.Initiative.Title": "Taking the Initiative",
-"WW.Combat.Initiative.Msg": "A new round started.",
-"WW.Combat.Initiative.Msg2": "Do you want to use a <b>reaction</b> to take the initiative, instead of making a regular turn?",
+"WW.Combat.Initiative.Msg": "<p>A new round started.</p><p>Do you want to use a <b>reaction</b> to take the initiative, instead of making a regular turn?</p>",
 "WW.Combat.Initiative.NoCharacter": "A new round started, but you don't have a character assigned to you.",
 
 "WW.Combat.ActAgain.Title": "Act Again",

--- a/lang/en.json
+++ b/lang/en.json
@@ -674,8 +674,9 @@
 
 "WW.Combat.Tip.RightClick": "Right click for context options.",
 "WW.Combat.Tip.FinishTurn": "Finish Your Turn",
-"WW.Combat.Tip.SkipActed": "Skip Acted?",
-"WW.Combat.Tip.SkipActedHint": "Automatically bypass combatants who acted already during this round.",
+
+"WW.Settings.Combat.SkipActed": "Skip Acted?",
+"WW.Settings.Combat.SkipActedHint": "Automatically bypass combatants who already acted during this round.",
 
 "WW.System.Help": "Help",
 

--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -35,14 +35,18 @@ export default class WWToken extends Token {
 
   _drawDamageBar(number, bar, data) {
     const { value, max } = data;
-    const colorPct = Math.clamped(value, 0, max) / max;
+    let colorPct = Math.clamped(value, 0, max) / max;
+    if (game.settings.get('weirdwizard', 'damageBarReverse')) {
+      colorPct = Math.clamped(max-value, 0, max) / max
+    }
     const damageColor = WWToken.getDamageColor(value, max);
 
     // Determine the container size (logic borrowed from core)
     const w = this.w;
     let h = Math.max(canvas.dimensions.size / 12, 8);
-    if (this.document.height >= 2)
+    if (this.document.height >= 2) {
       h *= 1.6;
+    }
     const stroke = Math.clamped(h / 8, 1, 2);
 
     // Set up bar container

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -390,8 +390,8 @@ export default class WWCombat extends Combat {
       } else {
 
         const confirm = await Dialog.confirm({
-          title: i18n('WW.Combat.TakingInit.Title'),
-          content: `<p>${i18n('WW.Combat.TakingInit.Msg')}</p><p>${i18n('WW.Combat.TakingInit.Msg2')}</p>`
+          title: i18n('WW.Combat.Initiative.Title'),
+          content: i18n('WW.Combat.Initiative.Msg')
         })
   
         // Check if the users's character is present as a combatant in the current combat

--- a/module/documents/combatant.mjs
+++ b/module/documents/combatant.mjs
@@ -42,9 +42,13 @@ export default class WWCombatant extends Combatant {
     /*if ( token.object ) await token.object.toggleEffect(effect, {overlay: true, active: taking});
     else await token.toggleActiveEffect(effect, {overlay: true, active: taking});*/
     
+    let msg = i18n('WW.Combat.Turn.Msg', {name: '<b>' + token.actor.name + '</b>'});
+    if (taking) {
+      msg = i18n('WW.Combat.Initiative.ChatMsg', {name: '<b>' + token.actor.name + '</b>'});
+    }
     // Send to chat
     ChatMessage.create({
-      content: '<div><b>' + token.actor.name + '</b> ' + (taking ? i18n('WW.Combat.Initiative.Msg') : i18n('WW.Combat.Turn.Msg')) + '.</div>',
+      content: '<div>' + msg + '</div>',
       sound: CONFIG.sounds.notification
     });
 

--- a/module/weirdwizard.mjs
+++ b/module/weirdwizard.mjs
@@ -135,6 +135,16 @@ Hooks.once('init', function () {
   //WWActiveEffectConfig.initializeChangePriorities(); // No longer needed
 
   // Register system settings
+  game.settings.register('weirdwizard', 'damageBarReverse', {
+    name: 'WW.Settings.DamageBarReverse',
+    hint: 'WW.Settings.DamageBarReverseHint',
+    scope: 'world',
+    config: true,
+    requiresReload: true,
+    type: Boolean,
+    default: false
+  });
+
   game.settings.register('weirdwizard', 'skipActed', {
     name: 'WW.Settings.Combat.SkipActed',
     hint: 'WW.Settings.Combat.SkipActedHint',

--- a/module/weirdwizard.mjs
+++ b/module/weirdwizard.mjs
@@ -136,8 +136,8 @@ Hooks.once('init', function () {
 
   // Register system settings
   game.settings.register('weirdwizard', 'skipActed', {
-    name: 'WW.Combat.Skip',
-    hint: 'WW.Combat.SkipHint',
+    name: 'WW.Settings.Combat.SkipActed',
+    hint: 'WW.Settings.Combat.SkipActedHint',
     scope: 'world',
     config: true,
     requiresReload: false,

--- a/module/weirdwizard.mjs
+++ b/module/weirdwizard.mjs
@@ -301,8 +301,7 @@ Hooks.on('renderChatMessage', (app, html) => {
 
   // Initialize chat message listeners
   initChatListeners(html, app);
-
-})
+});
 
 /* -------------------------------------------- */
 /*  Misc Hooks                                  */
@@ -328,7 +327,35 @@ Hooks.on('updateWorldTime', (worldTime, dt, options, userId) => {
   expireFromTokens();
 
   if (ui.questcalendar?.rendered) ui.questcalendar.render();
-})
+});
+
+Hooks.on('renderSettingsConfig', (app, html, data) => {
+  // Add sections to settings dialog by iterating all *our* settings, stripping the module/system ID,
+  // then checking whether they have the format '<section>.setting'.
+  // If so, we check whether the section matches the last section we saw;
+  // otherwise, this is a new section and we insert a new section header.
+  let lastSectionID = '';
+  const wwSettings = html.find(`.tab[data-tab=system] .form-group`)
+  wwSettings.each((i, value) => {
+    const setting = (value.getAttribute('data-setting-id') || '').replace(/^(weirdwizard\.)/, '');
+    if (!setting || setting.indexOf('.') < 1) {
+      return;
+    }
+    const section = setting.split('.')[0];
+    if (section !== lastSectionID) {
+      const key = 'WW.Settings.Section.' + section;
+      const hintKey = key + 'Hint';
+      let hint = game.i18n.localize(hintKey)
+      if (hint !== hintKey) {
+        hint = `<p class="notes">${hint}</p>`;
+      } else {
+        hint = '';
+      }
+      wwSettings.eq(i).before(`<h3>${game.i18n.localize(key)}</h3>${hint}`);
+      lastSectionID = section;
+    }
+  });
+});
 
 /* -------------------------------------------- */
 /*  External Module Hooks                       */

--- a/module/weirdwizard.mjs
+++ b/module/weirdwizard.mjs
@@ -115,11 +115,11 @@ Hooks.once('init', function () {
   CONFIG.Actor.trackableAttributes = {
     Character: {
       bar: ['stats.damage'],
-      value: []
+      value: ['stats.defense.total']
     },
     NPC: {
       bar: ['stats.damage'],
-      value: []
+      value: ['stats.defense.total']
     }
   };
 

--- a/templates/apps/combat-config.hbs
+++ b/templates/apps/combat-config.hbs
@@ -25,9 +25,9 @@
     </div>
 
     <div class="form-group">
-        <label>{{localize 'WW.Combat.SkipActed'}}</label>
+        <label>{{localize 'WW.Settings.Combat.SkipActed'}}</label>
         <input type="checkbox" name="skipActed" {{checked skipActed}} data-dtype="Boolean"/>
-        <p class="notes">{{localize 'WW.Combat.SkipActedHint'}}</p>
+        <p class="notes">{{localize 'WW.Settings.Combat.SkipActedHint'}}</p>
     </div>
     {{/if}}
 

--- a/templates/apps/combat-tracker.hbs
+++ b/templates/apps/combat-tracker.hbs
@@ -67,7 +67,7 @@
         </li>
         {{#each turns}}
         {{#if (and (eq this.type "Character") this.flags.weirdwizard.takingInit)}}
-        <li class="combatant actor directory-item flexrow{{#if this.flags.weirdwizard.acted}} acted{{/if}}{{#if this.injured}} injured{{/if}} {{this.css}}" title="{{localize "WW.Combat.Tip"}}" data-combatant-id="{{this.id}}">
+        <li class="combatant actor directory-item flexrow{{#if this.flags.weirdwizard.acted}} acted{{/if}}{{#if this.injured}} injured{{/if}} {{this.css}}" title="{{localize "WW.Combat.Tip.RightClick"}}" data-combatant-id="{{this.id}}">
             <img class="token-image" data-src="{{this.img}}" alt="{{this.name}}"/>
             <div class="token-name flexcol">
                 <h4>{{this.name}}</h4>
@@ -141,7 +141,7 @@
         </li>
         {{#each turns}}
         {{#if (eq this.type "NPC")}}
-        <li class="combatant actor directory-item flexrow{{#if this.flags.weirdwizard.acted}} acted{{/if}}{{#if this.injured}} injured{{/if}} {{this.css}}" title="{{localize "WW.Combat.Tip"}}" data-combatant-id="{{this.id}}">
+        <li class="combatant actor directory-item flexrow{{#if this.flags.weirdwizard.acted}} acted{{/if}}{{#if this.injured}} injured{{/if}} {{this.css}}" title="{{localize "WW.Combat.Tip.RightClick"}}" data-combatant-id="{{this.id}}">
             <img class="token-image" data-src="{{this.img}}" alt="{{this.name}}"/>
             <div class="token-name flexcol">
                 <h4>{{this.name}}</h4>
@@ -217,7 +217,7 @@
         </li>
         {{#each turns}}
         {{#if (and (eq this.type "Character") (not this.flags.weirdwizard.takingInit))}}
-        <li class="combatant actor directory-item flexrow{{#if this.flags.weirdwizard.acted}} acted{{/if}}{{#if this.injured}} injured{{/if}} {{this.css}}" title="{{localize "WW.Combat.Tip"}}" data-combatant-id="{{this.id}}">
+        <li class="combatant actor directory-item flexrow{{#if this.flags.weirdwizard.acted}} acted{{/if}}{{#if this.injured}} injured{{/if}} {{this.css}}" title="{{localize "WW.Combat.Tip.RightClick"}}" data-combatant-id="{{this.id}}">
             <img class="token-image" data-src="{{this.img}}" alt="{{this.name}}"/>
             <div class="token-name flexcol">
                 <h4>{{this.name}}</h4>

--- a/templates/apps/roll-attribute.hbs
+++ b/templates/apps/roll-attribute.hbs
@@ -48,7 +48,7 @@
             <i class="fas fa-dice"></i> {{localize "WW.Roll.Label"}}
         </button>
         <button type="button" id="boons-cancel">
-            <i class="fas fa-x"></i> {{localize "WW.Dialog.Cancel"}}
+            <i class="fas fa-x"></i> {{localize "WW.System.Dialog.Cancel"}}
         </button>
     </div>
 </form>

--- a/templates/apps/roll-damage.hbs
+++ b/templates/apps/roll-damage.hbs
@@ -62,7 +62,7 @@
             <i class="fas fa-dice"></i> {{localize "WW.Roll.Label"}}
         </button>
         <button type="button" id="damage-cancel">
-            <i class="fas fa-x"></i> {{localize "WW.Dialog.Cancel"}}
+            <i class="fas fa-x"></i> {{localize "WW.System.Dialog.Cancel"}}
         </button>
     </div>
 </form>


### PR DESCRIPTION
These are a bunch of miscellaneous smaller fixes and improvements while I continue translating the system. Comments welcome, happy to discuss, make changes or remove parts :)

----

### Add section support to settings

Add support for settings sections, although currently unused.

![settings-sections](https://github.com/Savantford/foundry-weirdwizard/assets/1654763/2b69e982-813d-42a1-98d4-a8079206d130)

Also added the possibility to have section hints (the text after the section header), because why not. Sections are automatically generated when settings of the format `<section>.<setting>` are registered, i.e., `game.settings.register('weirdwizard', 'newsection.somesetting'` would result in a new section, displayed as the translation string `WW.Settings.Section.newsection`, and if the translation string `WW.Settings.Section.newsectionHint` exists, that text is displayed immediately after the header.

----

### Allow tracking defense value in combat tracker

You can now optionally set the combat tracker to display defense values.

![ctset](https://github.com/Savantford/foundry-weirdwizard/assets/1654763/121a43ad-036c-451c-9a9d-021b3b398f36)

----

### Reverse damage bars

![tradhp](https://github.com/Savantford/foundry-weirdwizard/assets/1654763/0d10cc30-f344-4daa-9fb5-4d88fff3b2fa)

During my first playtests, I found the current health bars counterintuitive. I added a system setting (off by default) to invert the health bars, starting at 100% full for 0 damage, and decreasing to 0 as damage increases.

#### Comparison: 2 healthy units fighting one damaged unit in the middle / same but WITHOUT this new setting

![1](https://github.com/Savantford/foundry-weirdwizard/assets/1654763/4507d467-0393-4cd2-855b-99c7820c513a)

As I get why the current behaviour was implemented, more closely matching damage *increasing*, I have left this new behaviour off by default, just as an option. Happy to discuss!

----

### Initiative messages

Initiative/round/turn chat messages are now based on translated format strings. Also changed the message for taking the initiative from `<Name> A new round started..` to `<Name> is taking the initiative.` to match the other message better.

![iniafter](https://github.com/Savantford/foundry-weirdwizard/assets/1654763/f3e5b39d-7ab0-4259-ba9d-2f73c785bf8d)

----

Also:
- Fixes localization of the "Skip acted" system setting
- Fixes wrong translation string references for combat tracker tooltips
- Removes `WW.Dialog.Cancel` translation string again, as we already have `WW.System.Dialog.Cancel` which we can use which I missed