### PR TITLE
Allow translation of weapon grip

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -314,8 +314,11 @@
 
 "WW.Weapon.Grip.Label": "Grip",
 "WW.Weapon.Grip.One": "One-Handed",
+"WW.Weapon.Grip.OneShort": "One",
 "WW.Weapon.Grip.Two": "Two-Handed",
+"WW.Weapon.Grip.TwoShort": "Two",
 "WW.Weapon.Grip.Off": "Off-Hand",
+"WW.Weapon.Grip.OffShort": "Off",
 
 "WW.Weapon.Requirements.Label": "Requires",
 "WW.Weapon.Requirements.None": "—",

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -163,8 +163,7 @@ export default class WWActorSheet extends ActorSheet {
         }
 
         // Is the item an activity?
-        i.isActivity = false;
-        if (i.system.attribute || i.effects.length || i.system.instant.length) i.isActivity = true;
+        i.isActivity = i.system.attribute || i.effects.length || i.system.instant.length;
 
         // Check if item has passive effects
         i.hasPassiveEffects = false;

--- a/templates/actors/parts/Character-equipment.hbs
+++ b/templates/actors/parts/Character-equipment.hbs
@@ -91,7 +91,7 @@
             </div>
             
             <div class="item-fixed"><a>{{item.system.damage}}</a></div>
-            <div class="item-fixed">{{item.system.grip}}</div>
+            <div class="item-fixed">{{localize (concat 'WW.Weapon.Grip.' item.system.grip 'Short')}}</div>
             <div class="item-traits">{{item.system.traitsList}}</div>
 
             <div class="item-controls">              

--- a/templates/actors/parts/Character-summary-weapon.hbs
+++ b/templates/actors/parts/Character-summary-weapon.hbs
@@ -38,7 +38,7 @@
     </span>
 
     {{!-- Traits --}}
-    <span class="traits-line">({{item.system.grip}}{{#if item.system.traitsList}};
+    <span class="traits-line">({{localize (concat 'WW.Weapon.Grip.' item.system.grip 'Short')}}{{#if item.system.traitsList}};
         {{item.system.traitsList}}{{/if}})</span>
 
     {{!-- Modifier --}}


### PR DESCRIPTION
This properly translates the weapon grips displayed in item infos on the character sheet summary and equipment tabs.
Also adds new `Short` grip translation keys (`Off` instead of `Off-Hand`, `Two` instead of `Two-Handed`) to keep it the same as before, because the longer names are too long for those summaries.