### PR TITLE
Filter weapons from equipment list on character sheet, instead of listing them twice

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -204,11 +204,11 @@ export default class WWActorSheet extends ActorSheet {
             i.label = (i.system.traits.range ? i18n('WW.Attack.Ranged') : i18n('WW.Attack.Melee')) + '—' + i.name + (i.system.traitsList ? ' ● ' + i.system.traitsList : '');
           }
 
-          equipment.push(i);
-
-          // If an weapon or NPC sheet, also append to weapons.
+          // If an weapon or NPC sheet, append to weapons.
           if ((i.system.subtype == 'weapon') || (context.actor.type == 'NPC')) {
             weapons.push(i);
+          } else {
+            equipment.push(i);
           }
         }
 


### PR DESCRIPTION
This filters weapons from the equipment section on the *Equipment* tab on character sheets, so they're only listed once, under *Weapons*, instead of in both sections.

Not sure if there was a reason for listing them twice?