### PR TITLE
Use Foundry tooltips

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -691,11 +691,11 @@ export default class WWActorSheet extends ActorSheet {
     
     // Flip states
     if (icon.hasClass('fa-square-chevron-down')) {
-      $(button).attr("title", i18n('WW.Item.HideDesc'))
+      $(button).attr('data-tooltip', i18n('WW.Item.HideDesc'))
       icon.removeClass('fa-square-chevron-down').addClass('fa-square-chevron-up');
       desc.slideDown(500);
     } else {
-      $(button).attr("title", i18n('WW.Item.ShowDesc'))
+      $(button).attr('data-tooltip', i18n('WW.Item.ShowDesc'))
       icon.removeClass('fa-square-chevron-up').addClass('fa-square-chevron-down');
       desc.slideUp(500);
     }

--- a/templates/actors/Character-sheet.hbs
+++ b/templates/actors/Character-sheet.hbs
@@ -16,13 +16,13 @@
             </div>
 
             <div class="circle" style="--total: 4">
-                <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="100" width="100"/>
+                <img class="profile-img" src="{{actor.img}}" data-edit="img" data-tooltip="{{actor.name}}" height="100" width="100"/>
                 
                 <div class="stat" style="--i:1">
                     <label class="resource-label">{{localize "WW.Attributes.StrengthShort"}}</label>
                     <div>
                         <input type="number" name="system.attributes.str.value" value="{{system.attributes.str.value}}" min="0" data-dtype="Number"/>
-                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="str" title="Roll Strength">
+                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="str" data-tooltip="Roll Strength">
                             {{#if system.attributes.str.value}}
                             {{numberFormat system.attributes.str.mod decimals=0 sign=true}}
                             {{else}}—{{/if}}
@@ -34,7 +34,7 @@
                     <label class="resource-label">{{localize "WW.Attributes.AgilityShort"}}</label>
                     <div>
                         <input type="number" name="system.attributes.agi.value" value="{{system.attributes.agi.value}}" min="0" data-dtype="Number"/>
-                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="agi" title="Roll Agility">
+                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="agi" data-tooltip="Roll Agility">
                             {{#if system.attributes.agi.value}}
                             {{numberFormat system.attributes.agi.mod decimals=0 sign=true}}
                             {{else}}—{{/if}}
@@ -47,7 +47,7 @@
                     <label class="resource-label">{{localize "WW.Attributes.IntellectShort"}}</label>
                     <div>
                         <input type="number" name="system.attributes.int.value" value="{{system.attributes.int.value}}" min="0" data-dtype="Number"/>
-                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="int" title="Roll Intellect">
+                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="int" data-tooltip="Roll Intellect">
                             {{#if system.attributes.int.value}}
                             {{numberFormat system.attributes.int.mod decimals=0 sign=true}}
                             {{else}}—{{/if}}
@@ -59,7 +59,7 @@
                     <label class="resource-label">{{localize "WW.Attributes.WillShort"}}</label>
                     <div>
                         <input type="number" name="system.attributes.wil.value" value="{{system.attributes.wil.value}}" min="0" data-dtype="Number"/>
-                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="wil" title="Roll Will">
+                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="wil" data-tooltip="Roll Will">
                             {{#if system.attributes.wil.value}}
                             {{numberFormat system.attributes.wil.mod decimals=0 sign=true}}
                             {{else}}—{{/if}}
@@ -87,14 +87,14 @@
                     <div class="stat">
                         <label>{{localize "WW.Defense.Label"}}</label>
 
-                        <div><a title="{{localize "WW.Defense.Natural"}}: {{system.stats.defense.natural}}">{{system.stats.defense.total}}</a></div>
+                        <div><a data-tooltip="{{localize "WW.Defense.Natural"}}: {{system.stats.defense.natural}}">{{system.stats.defense.total}}</a></div>
                     </div>
 
                     {{!-- Health --}}
                     <div class="stat">
                         <label>{{localize "WW.Health.Label"}}</label>
 
-                        <div><a title="{{localize "WW.Health.Normal"}}: {{system.stats.health.normal}}. {{localize "WW.Health.Bonus"}}: {{system.stats.health.bonus}}. {{localize "WW.Health.Lost"}}: {{system.stats.health.lost}}">{{system.stats.health.current}}</a></div>
+                        <div><a data-tooltip="{{localize "WW.Health.Normal"}}: {{system.stats.health.normal}}. {{localize "WW.Health.Bonus"}}: {{system.stats.health.bonus}}. {{localize "WW.Health.Lost"}}: {{system.stats.health.lost}}">{{system.stats.health.current}}</a></div>
                     </div>
 
                     {{!-- Damage --}}
@@ -108,7 +108,7 @@
                                 <div class="input-overlay">{{system.stats.damage.value}}</div>
                             </div>
                             
-                            <i class="health-indicator fas {{#if incapacitated}}fa-octagon-xmark{{else if injured}}fa-droplet{{/if}}" title="
+                            <i class="health-indicator fas {{#if incapacitated}}fa-octagon-xmark{{else if injured}}fa-droplet{{/if}}" data-tooltip="
                                 {{#if incapacitated}}{{localize "WW.Health.Incapacitated"}}
                                 {{else}}{{localize "WW.Health.Injured"}}{{/if}}">
                             </i>
@@ -141,7 +141,7 @@
                         <div class="mr-2 luck">
                             <label>{{localize "WW.Attributes.Luck"}}</label>
 
-                            <div><a class="item-button resource-label" data-action="attribute-roll" data-key="luck" title="Roll {{localize "WW.Attributes.Luck"}}"><i class="large fas fa-dice-d20"></i></a></div>
+                            <div><a class="item-button resource-label" data-action="attribute-roll" data-key="luck" data-tooltip="Roll {{localize "WW.Attributes.Luck"}}"><i class="large fas fa-dice-d20"></i></a></div>
                         </div>
 
                         {{!-- Rest --}}

--- a/templates/actors/parts/Character-effects.hbs
+++ b/templates/actors/parts/Character-effects.hbs
@@ -4,7 +4,7 @@
   {{#*inline "WWAffliction"}}
     <div class="affliction selectable {{#if value}}selected{{/if}}"
         style="width: auto; margin: 2px"
-        {{#if tooltip}}title="{{localize tooltip}}"{{/if}}>
+        {{#if tooltip}}data-tooltip="{{localize tooltip}}"{{/if}}>
       <input type="checkbox" id="data.{{name}}" data-name="{{name}}" {{checked value}}/>
       <i class="icon-{{name}}"></i>
       <span class="sep"></span>
@@ -89,7 +89,7 @@
       
       <div class="item-controls effect-controls flexrow">
         {{#if section.showCreate}}
-        <a class="effect-control" data-action="create" title="{{localize 'WW.Effect.Create'}}">
+        <a class="effect-control" data-action="create" data-tooltip="{{localize 'WW.Effect.Create'}}">
           <i class="fas fa-plus"></i> {{localize "WW.Item.Add.Label"}}
         </a>
         {{/if}}
@@ -124,15 +124,15 @@
         <div class="item-controls effect-controls flexrow">
           {{#if (or (eq effect.parent.type 'Character') (eq effect.parent.type 'NPC'))}}
           {{#if (ne section.type 'temporary')}}
-          <a class="effect-control" data-action="toggle" title="{{localize 'WW.Effect.Toggle'}}">
+          <a class="effect-control" data-action="toggle" data-tooltip="{{localize 'WW.Effect.Toggle'}}">
             <i class="fas {{#if effect.disabled}}fa-toggle-off{{else}}fa-toggle-on{{/if}}"></i>
           </a>
           {{/if}}
 
-          <a class="effect-control" data-action="edit" title="{{localize 'WW.Effect.Edit'}}">
+          <a class="effect-control" data-action="edit" data-tooltip="{{localize 'WW.Effect.Edit'}}">
             <i class="fas fa-edit"></i>
           </a>
-          <a class="effect-control" data-action="delete" title="{{localize 'WW.Effect.Delete'}}">
+          <a class="effect-control" data-action="delete" data-tooltip="{{localize 'WW.Effect.Delete'}}">
             <i class="fas fa-trash"></i>
           </a>
           {{/if}}
@@ -153,7 +153,7 @@
 
       <div class="item-controls effect-controls flexrow">
         {{#if actorEffects.inactive.showCreate}}
-        <a class="effect-control" data-action="create" title="{{localize 'WW.Effect.Create'}}">
+        <a class="effect-control" data-action="create" data-tooltip="{{localize 'WW.Effect.Create'}}">
           <i class="fas fa-plus"></i> {{localize "WW.Item.Add.Label"}}
         </a>
         {{/if}}
@@ -187,14 +187,14 @@
         <div class="item-controls effect-controls flexrow">
           {{#if ../actorEffects.inactive.showControls}}
 
-          <a class="effect-control" data-action="toggle" title="{{localize 'WW.EffectToggle'}}">
+          <a class="effect-control" data-action="toggle" data-tooltip="{{localize 'WW.EffectToggle'}}">
             <i class="fas {{#if effect.disabled}}fa-toggle-off{{else}}fa-toggle-on{{/if}}"></i>
           </a>
           
-          <a class="effect-control" data-action="edit" title="{{localize 'WW.EffectEdit'}}">
+          <a class="effect-control" data-action="edit" data-tooltip="{{localize 'WW.EffectEdit'}}">
             <i class="fas fa-edit"></i>
           </a>
-          <a class="effect-control" data-action="delete" title="{{localize 'WW.EffectDelete'}}">
+          <a class="effect-control" data-action="delete" data-tooltip="{{localize 'WW.EffectDelete'}}">
             <i class="fas fa-trash"></i>
           </a>
           {{/if}}

--- a/templates/actors/parts/Character-equipment.hbs
+++ b/templates/actors/parts/Character-equipment.hbs
@@ -63,7 +63,7 @@
             <div class="item-fixed">{{localize "WW.Weapon.Grip.Label"}}</div>
             <div class="item-traits">{{localize "WW.Weapon.Traits.Label"}}</div>
             <div class="item-controls">
-                <a class="item-control item-create" title="Create item" data-type="Equipment" data-subtype="weapon"><i
+                <a class="item-control item-create" data-tooltip="Create item" data-type="Equipment" data-subtype="weapon"><i
                     class="fas fa-plus"></i> {{localize "WW.Item.Add.Label"}}</a>
             </div>
         </li>
@@ -71,14 +71,14 @@
         {{#each weapons as |item id|}}
         <li class="item flexrow flex-group-left" data-item-id="{{item._id}}">
             {{!-- Icon --}}
-            <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
+            <div class="item-image"><img src="{{item.img}}" data-tooltip="{{item.name}}" width="24" height="24" /></div>
 
             <div class="item-name">
                 {{!-- Title --}}
                 {{#if item.needTargets}}<label class="item-button" data-action="targeted-use" data-item-id="{{item._id}}" 
-                    title="{{localize "WW.Targeting.AttackTargeted"}}">{{item.name}}</label>
+                    data-tooltip="{{localize "WW.Targeting.AttackTargeted"}}">{{item.name}}</label>
                 {{else if item.isActivity}}<label class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-                    title="{{localize "WW.Targeting.AttackUntargeted"}}">{{item.name}}</label>
+                    data-tooltip="{{localize "WW.Targeting.AttackUntargeted"}}">{{item.name}}</label>
                 {{else}}<label>{{item.name}}</label>{{/if}}
 
                 <span class="buttons">
@@ -87,12 +87,12 @@
 
                         {{#if item.needTargets}}
                         <a class="item-button" data-action="targeted-use" data-item-id="{{item._id}}"
-                            title="{{localize "WW.Targeting.AttackTargeted"}}">
+                            data-tooltip="{{localize "WW.Targeting.AttackTargeted"}}">
                         <i class="fas fa-bullseye"></i></a>
                         {{/if}}
 
                         <a class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-                            title="{{localize "WW.Targeting.AttackUntargeted"}}">
+                            data-tooltip="{{localize "WW.Targeting.AttackUntargeted"}}">
                         <i class="fas fa-bolt"></i></a>
 
                     {{/if}}
@@ -100,7 +100,7 @@
                     {{!-- Toggle Reloaded --}}
                     {{#if item.system.disadvantages.reload}}
                     <a class="item-button" data-action="item-toggle-reloaded" data-item-id="{{item._id}}"
-                        title="{{#if item.system.reloaded}}{{localize "WW.Weapon.Fire"}}{{else}}{{localize "WW.Weapon.Reload"}}{{/if}}">
+                        data-tooltip="{{#if item.system.reloaded}}{{localize "WW.Weapon.Fire"}}{{else}}{{localize "WW.Weapon.Reload"}}{{/if}}">
                     <i class="fas {{#if item.system.reloaded}}fa-hexagon-check{{else}}fa-arrows-rotate{{/if}}"></i></a>
                     {{/if}}
                     
@@ -120,11 +120,11 @@
             <div class="item-controls">              
                 {{!-- Edit Button --}}
                 <a class="item-button" data-action="item-edit" data-item-id="{{item._id}}"
-                    title="{{localize "WW.Item.Edit.Weapon"}}">
+                    data-tooltip="{{localize "WW.Item.Edit.Weapon"}}">
                 <i class="fas fa-edit"></i></a>
 
                 {{!-- Delete Button --}}
-                <a class="item-button" data-action="item-delete" data-item-id="{{item._id}}" title="Delete Item"><i class="fas fa-trash"></i></a>
+                <a class="item-button" data-action="item-delete" data-item-id="{{item._id}}" data-tooltip="Delete Item"><i class="fas fa-trash"></i></a>
             </div>
         </li>
         {{/each}}
@@ -142,14 +142,14 @@
             <div class="item-uses">{{localize "WW.Equipment.Uses"}}</div>
             <div class="item-weight">{{localize "WW.Equipment.Weight"}}</div>
             <div class="item-controls">
-                <a class="item-control item-create" title="Create item" data-type="Equipment" data-subtype="generic"><i class="fas fa-plus"></i> {{localize "WW.Item.Add.Label"}}</a>
+                <a class="item-control item-create" data-tooltip="Create item" data-type="Equipment" data-subtype="generic"><i class="fas fa-plus"></i> {{localize "WW.Item.Add.Label"}}</a>
             </div>
         </li>
 
         {{#each equipment as |item id|}}
         <li class="item flexrow" data-item-id="{{item._id}}">
             {{!-- Icon --}}
-            <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
+            <div class="item-image"><img src="{{item.img}}" data-tooltip="{{item.name}}" width="24" height="24" /></div>
 
             {{!-- Quantity --}}
             <div class="item-quantity">{{item.system.quantity}}</div>
@@ -157,9 +157,9 @@
             <div class="item-name">
                 {{!-- Title --}}
                 {{#if item.needTargets}}<label class="item-button" data-action="targeted-use" data-item-id="{{item._id}}" 
-                    title="{{localize "WW.Targeting.EquipmentTargeted"}}">{{item.name}}</label>
+                    data-tooltip="{{localize "WW.Targeting.EquipmentTargeted"}}">{{item.name}}</label>
                 {{else if item.isActivity}}<label class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-                    title="{{localize "WW.Targeting.EquipmentUntargeted"}}">{{item.name}}</label>
+                    data-tooltip="{{localize "WW.Targeting.EquipmentUntargeted"}}">{{item.name}}</label>
                 {{else}}<label>{{item.name}}</label>{{/if}}
 
                 <span class="buttons">
@@ -168,12 +168,12 @@
 
                         {{#if item.needTargets}}
                         <a class="item-button" data-action="targeted-use" data-item-id="{{item._id}}"
-                            title="{{localize "WW.Targeting.EquipmentTargeted"}}">
+                            data-tooltip="{{localize "WW.Targeting.EquipmentTargeted"}}">
                         <i class="fas fa-bullseye"></i></a>
                         {{/if}}
 
                         <a class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-                            title="{{localize "WW.Targeting.EquipmentUntargeted"}}">
+                            data-tooltip="{{localize "WW.Targeting.EquipmentUntargeted"}}">
                         <i class="fas fa-bolt"></i></a>
 
                     {{/if}}
@@ -181,7 +181,7 @@
                     {{!-- Toggle Effects --}}
                     {{#if item.hasPassiveEffects}}
                         <a class="item-button" data-action="item-toggle-effects" data-item-id="{{item._id}}"
-                            title="{{#if item.system.active}}{{localize "WW.Item.DisableEffects"}}{{else}}{{localize "WW.Item.EnableEffects"}}{{/if}}">
+                            data-tooltip="{{#if item.system.active}}{{localize "WW.Item.DisableEffects"}}{{else}}{{localize "WW.Item.EnableEffects"}}{{/if}}">
                             <i class="fas {{#if item.system.active}}fa-toggle-on{{else}}fa-toggle-off{{/if}}"></i></a>
                     {{/if}}
 
@@ -200,7 +200,7 @@
                 <span class="pip-box">
                     {{#each item.uses as |pip id|}}
                     <a class="item-pip" data-item-id="{{item._id}}"
-                        title="{{#if (eq pip "far fa-circle")}}{{localize "WW.Item.Uses.EquipmentSpend"}}{{else}}{{localize "WW.Item.Uses.EquipmentRecover"}}{{/if}}">
+                        data-tooltip="{{#if (eq pip "far fa-circle")}}{{localize "WW.Item.Uses.EquipmentSpend"}}{{else}}{{localize "WW.Item.Uses.EquipmentRecover"}}{{/if}}">
                     <i class="{{pip}}"></i></a>
                     {{/each}}
                 </span>
@@ -213,11 +213,11 @@
             <div class="item-controls">              
                 {{!-- Edit Button --}}
                 <a class="item-button" data-action="item-edit" data-item-id="{{item._id}}"
-                    title="{{localize "WW.Item.Edit.Equipment"}}">
+                    data-tooltip="{{localize "WW.Item.Edit.Equipment"}}">
                 <i class="fas fa-edit"></i></a>
 
                 {{!-- Delete Button --}}
-                <a class="item-button" data-action="item-delete" data-item-id="{{item._id}}" title="Delete Item"><i class="fas fa-trash"></i></a>
+                <a class="item-button" data-action="item-delete" data-item-id="{{item._id}}" data-tooltip="Delete Item"><i class="fas fa-trash"></i></a>
             </div>
         </li>
         {{/each}}

--- a/templates/actors/parts/Character-summary-weapon.hbs
+++ b/templates/actors/parts/Character-summary-weapon.hbs
@@ -1,26 +1,26 @@
 <li class="item" data-item-id="{{item._id}}">
     {{!-- Title --}}
     {{#if item.needTargets}}<label class="item-button" data-action="targeted-use" data-item-id="{{item._id}}" 
-        title="{{localize "WW.Targeting.AttackTargeted"}}">{{item.name}}</label>
+        data-tooltip="{{localize "WW.Targeting.AttackTargeted"}}">{{item.name}}</label>
     {{else if item.isActivity}}<label class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-        title="{{localize "WW.Targeting.AttackUntargeted"}}">{{item.name}}</label>
+        data-tooltip="{{localize "WW.Targeting.AttackUntargeted"}}">{{item.name}}</label>
     {{else}}<label>{{item.name}}</label>{{/if}}
 
     <span class="buttons">
 
         {{!-- Use Buttons --}}
         <a class="item-button" data-action="targeted-use" data-item-id="{{item._id}}"
-            title="{{localize "WW.Targeting.AttackTargeted"}}">
+            data-tooltip="{{localize "WW.Targeting.AttackTargeted"}}">
         <i class="fas fa-bullseye"></i></a>
 
         <a class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-            title="{{localize "WW.Targeting.AttackUntargeted"}}">
+            data-tooltip="{{localize "WW.Targeting.AttackUntargeted"}}">
         <i class="fas fa-bolt"></i></a>
 
         {{!-- Toggle Reloaded --}}
         {{#if item.system.disadvantages.reload}}
         <a class="item-button" data-action="item-toggle-reloaded" data-item-id="{{item._id}}"
-            title="{{#if item.system.reloaded}}{{localize "WW.Weapon.Fire"}}{{else}}{{localize "WW.Weapon.Reload"}}{{/if}}">
+            data-tooltip="{{#if item.system.reloaded}}{{localize "WW.Weapon.Fire"}}{{else}}{{localize "WW.Weapon.Reload"}}{{/if}}">
         <i class="fas {{#if item.system.reloaded}}fa-hexagon-check{{else}}fa-arrows-rotate{{/if}}"></i></a>
         {{/if}}
         
@@ -33,7 +33,7 @@
 
         {{!-- Edit Button --}}
         <a class="item-button" data-action="item-edit" data-item-id="{{item._id}}"
-            title="{{localize "WW.Item.Edit.Weapon"}}">
+            data-tooltip="{{localize "WW.Item.Edit.Weapon"}}">
         <i class="fas fa-edit"></i></a>
     </span>
 

--- a/templates/actors/parts/NPC-summary.hbs
+++ b/templates/actors/parts/NPC-summary.hbs
@@ -14,10 +14,10 @@
                     <a class="array-button" data-action="edit" data-array="details.descriptors" data-entry-id="{{id}}"
                         data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
                         <a class="array-button" data-action="edit" data-array="details.descriptors" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Descriptor.Edit"}}"><i class="fas fa-edit"></i></a>
+                            data-tooltip="{{localize "WW.Detail.Descriptor.Edit"}}"><i class="fas fa-edit"></i></a>
                 
                         <a class="array-button" data-action="remove" data-array="details.descriptors" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Descriptor.Remove"}}"><i class="fas fa-trash"></i></a>
+                            data-tooltip="{{localize "WW.Detail.Descriptor.Remove"}}"><i class="fas fa-trash"></i></a>
                     </span>{{#unless @last}},{{/unless}}
 
                 </span>
@@ -26,7 +26,7 @@
                 {{#unless system.details.descriptors.length}}{{localize "WW.Detail.Descriptor.None"}}{{/unless}}
                 
                 <a class="array-button" data-action="add" data-array="details.descriptors" data-loc="Descriptor"
-                    title="{{localize "WW.Detail.Descriptor.Add"}}"><i class="fas fa-circle-plus"></i></a>
+                    data-tooltip="{{localize "WW.Detail.Descriptor.Add"}}"><i class="fas fa-circle-plus"></i></a>
 
             </span>
 
@@ -58,17 +58,17 @@
                 
                     {{#if system.stats.defense.details}}({{/if}}<input class="stat-edit" type="text"
                         name="system.stats.defense.details" value="{{system.stats.defense.details}}" data-dtype="String"
-                        title="{{localize "WW.Defense.Details"}}" />{{#if system.stats.defense.details}}){{/if}}
+                        data-tooltip="{{localize "WW.Defense.Details"}}" />{{#if system.stats.defense.details}}){{/if}}
                 </div>
 
                 {{!-- Health --}}
                 <div class="nowrap">
                     <label>{{localize "WW.Health.Label"}}:</label>
 
-                    <a title="{{localize "WW.Health.Bonus"}}: {{system.stats.health.bonus}}. {{localize "WW.Health.Lost"}}: {{system.stats.health.lost}}">{{system.stats.health.current}}</a>
+                    <a data-tooltip="{{localize "WW.Health.Bonus"}}: {{system.stats.health.bonus}}. {{localize "WW.Health.Lost"}}: {{system.stats.health.lost}}">{{system.stats.health.current}}</a>
                     
                     {{!-- <input type="number" name="system.stats.health.current" value="{{system.stats.health.current}}" min="0"
-                        data-dtype="Number" title="{{localize "WW.Health.Bonus"}}: {{system.stats.health.bonus}}. {{localize "WW.Health.Lost"}}: {{system.stats.health.lost}}"/> --}}
+                        data-dtype="Number" data-tooltip="{{localize "WW.Health.Bonus"}}: {{system.stats.health.bonus}}. {{localize "WW.Health.Lost"}}: {{system.stats.health.lost}}"/> --}}
 
                     <span class="stat-edit">
                         <label>{{localize "WW.Stats.Normal"}}:</label>
@@ -94,7 +94,7 @@
                         <div class="input-overlay">{{system.stats.damage.value}}</div>
                     </div>
 
-                    <i class="health-indicator fas {{#if incapacitated}}fa-octagon-xmark{{else if injured}}fa-droplet{{/if}}" title="
+                    <i class="health-indicator fas {{#if incapacitated}}fa-octagon-xmark{{else if injured}}fa-droplet{{/if}}" data-tooltip="
                         {{#if incapacitated}}{{localize "WW.Health.Incapacitated"}}
                         {{else}}{{localize "WW.Health.Injured"}}{{/if}}">
                     </i>
@@ -105,7 +105,7 @@
             <div class="mt-1 stat-inline">
 
                 {{!-- Strength --}}
-                <label><a class="item-button" data-action="attribute-roll" data-key="str" title="Roll Strength">{{localize "WW.Attributes.Strength"}}:</a></label>
+                <label><a class="item-button" data-action="attribute-roll" data-key="str" data-tooltip="Roll Strength">{{localize "WW.Attributes.Strength"}}:</a></label>
 
                 <div class="input-wrap">
                     <input type="number" name="system.attributes.str.value"
@@ -115,13 +115,13 @@
                 </div>
                     
                 {{#if system.attributes.str.value}}
-                <a class="attribute-mod item-button" data-action="attribute-roll" data-key="str" title="Roll Strength">
+                <a class="attribute-mod item-button" data-action="attribute-roll" data-key="str" data-tooltip="Roll Strength">
                     ({{numberFormat system.attributes.str.mod decimals=0 sign=true}})
                 </a>
                 {{/if}}
                 
                 {{!-- Agility --}}
-                <label class="ml-1"><a class="item-button" data-action="attribute-roll" data-key="agi" title="Roll Agility">{{localize "WW.Attributes.Agility"}}:</a></label>
+                <label class="ml-1"><a class="item-button" data-action="attribute-roll" data-key="agi" data-tooltip="Roll Agility">{{localize "WW.Attributes.Agility"}}:</a></label>
 
                 <div class="input-wrap">
                     <input type="number" name="system.attributes.agi.value"
@@ -131,7 +131,7 @@
                 </div>
                 
                 {{#if system.attributes.agi.value}}
-                <a class="attribute-mod item-button" data-action="attribute-roll" data-key="agi" title="Roll Agility">
+                <a class="attribute-mod item-button" data-action="attribute-roll" data-key="agi" data-tooltip="Roll Agility">
                     ({{numberFormat system.attributes.agi.mod decimals=0 sign=true}})
                 </a>
                 {{/if}}
@@ -142,7 +142,7 @@
             <div class="mt-1 stat-inline">
 
                 {{!-- Intellect --}}
-                <label><a class="item-button" data-action="attribute-roll" data-key="int" title="Roll Intellect">{{localize "WW.Attributes.Intellect"}}:</a></label>
+                <label><a class="item-button" data-action="attribute-roll" data-key="int" data-tooltip="Roll Intellect">{{localize "WW.Attributes.Intellect"}}:</a></label>
                 
                 <div class="input-wrap">
                     <input type="number" name="system.attributes.int.value"
@@ -152,13 +152,13 @@
                 </div>
                 
                 {{#if system.attributes.int.value}}
-                <a class="attribute-mod item-button" data-action="attribute-roll" data-key="int" title="Roll Intellect">
+                <a class="attribute-mod item-button" data-action="attribute-roll" data-key="int" data-tooltip="Roll Intellect">
                     ({{numberFormat system.attributes.int.mod decimals=0 sign=true}})
                 </a>
                 {{/if}}
                 
                 {{!-- Will --}}
-                <label class="ml-1"><a class="item-button" data-action="attribute-roll" data-key="wil" title="Roll Will">{{localize "WW.Attributes.Will"}}:</a></label>
+                <label class="ml-1"><a class="item-button" data-action="attribute-roll" data-key="wil" data-tooltip="Roll Will">{{localize "WW.Attributes.Will"}}:</a></label>
 
                 <div class="input-wrap">
                     <input type="number" name="system.attributes.wil.value"
@@ -168,7 +168,7 @@
                 </div>
                 
                 {{#if system.attributes.wil.value}}
-                <a class="attribute-mod item-button" data-action="attribute-roll" data-key="wil" title="Roll Will">
+                <a class="attribute-mod item-button" data-action="attribute-roll" data-key="wil" data-tooltip="Roll Will">
                     ({{numberFormat system.attributes.wil.mod decimals=0 sign=true}})
                 </a>
                 {{/if}}
@@ -206,16 +206,16 @@
                         data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
                         
                         <a class="array-button" data-action="edit" data-array="details.movementTraits" data-entry-id="{{id}}"
-                            title="{{localize "WW.Movement.Edit"}}"><i class="fas fa-edit"></i></a>
+                            data-tooltip="{{localize "WW.Movement.Edit"}}"><i class="fas fa-edit"></i></a>
                         
                         <a class="array-button" data-action="remove" data-array="details.movementTraits" data-entry-id="{{id}}"
-                            title="{{localize "WW.Movement.Remove"}}"><i class="fas fa-trash"></i></a>
+                            data-tooltip="{{localize "WW.Movement.Remove"}}"><i class="fas fa-trash"></i></a>
                     </span>{{#unless @last}},{{/unless}}{{#if @last}}){{/if}}
                 </span>
                 {{/each}}
 
                 <a class="array-button" data-action="add" data-array="details.movementTraits" data-loc="Movement"
-                    title="{{localize "WW.Movement.Add"}}"><i class="fas fa-circle-plus"></i></a>
+                    data-tooltip="{{localize "WW.Movement.Add"}}"><i class="fas fa-circle-plus"></i></a>
 
             </div>
             
@@ -235,10 +235,10 @@
                         data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
                         
                         <a class="array-button" data-action="edit" data-array="details.languages" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Language.Edit"}}"><i class="fas fa-edit"></i></a>
+                            data-tooltip="{{localize "WW.Detail.Language.Edit"}}"><i class="fas fa-edit"></i></a>
                 
                         <a class="array-button" data-action="remove" data-array="details.languages" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Language.Remove"}}"><i class="fas fa-trash"></i></a>
+                            data-tooltip="{{localize "WW.Detail.Language.Remove"}}"><i class="fas fa-trash"></i></a>
                     </span>{{#unless @last}},{{/unless}}
                 </span>
                 {{/each}}
@@ -246,7 +246,7 @@
                 {{#unless system.details.languages.length}}—{{/unless}}
                 
                 <a class="array-button" data-action="add" data-array="details.languages" data-loc="Language"
-                    title="{{localize "WW.Detail.Language.Add"}}"><i class="fas fa-circle-plus"></i></a>
+                    data-tooltip="{{localize "WW.Detail.Language.Add"}}"><i class="fas fa-circle-plus"></i></a>
 
             </div>
 
@@ -260,10 +260,10 @@
                     <a class="array-button" data-action="edit" data-array="details.senses" data-entry-id="{{id}}"
                         data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
                         <a class="array-button" data-action="edit" data-array="details.senses" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Sense.Edit"}}"><i class="fas fa-edit"></i></a>
+                            data-tooltip="{{localize "WW.Detail.Sense.Edit"}}"><i class="fas fa-edit"></i></a>
                 
                         <a class="array-button" data-action="remove" data-array="details.senses" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Sense.Remove"}}"><i class="fas fa-trash"></i></a>
+                            data-tooltip="{{localize "WW.Detail.Sense.Remove"}}"><i class="fas fa-trash"></i></a>
                     </span>{{#unless @last}},{{/unless}}
 
                 </span>
@@ -272,7 +272,7 @@
                 {{#unless system.details.senses.length}}—{{/unless}}
                 
                 <a class="array-button" data-action="add" data-array="details.senses" data-loc="Sense"
-                    title="{{localize "WW.Detail.Sense.Add"}}"><i class="fas fa-circle-plus"></i></a>
+                    data-tooltip="{{localize "WW.Detail.Sense.Add"}}"><i class="fas fa-circle-plus"></i></a>
 
             </div>
 
@@ -287,10 +287,10 @@
                     <a class="array-button" data-action="edit" data-array="details.immune" data-entry-id="{{id}}"
                         data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
                         <a class="array-button" data-action="edit" data-array="details.immune" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Immune.Edit"}}"><i class="fas fa-edit"></i></a>
+                            data-tooltip="{{localize "WW.Detail.Immune.Edit"}}"><i class="fas fa-edit"></i></a>
                             
                         <a class="array-button" data-action="remove" data-array="details.immune" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Immune.Remove"}}"><i class="fas fa-trash"></i></a>
+                            data-tooltip="{{localize "WW.Detail.Immune.Remove"}}"><i class="fas fa-trash"></i></a>
                     </span>{{#unless @last}},{{/unless}}
 
                 </span>
@@ -299,7 +299,7 @@
                 {{#unless system.details.immune.length}}—{{/unless}}
 
                 <a class="array-button" data-action="add" data-array="details.immune" data-loc="Immune"
-                    title="{{localize "WW.Detail.Immune.Add"}}"><i class="fas fa-circle-plus"></i></a>        
+                    data-tooltip="{{localize "WW.Detail.Immune.Add"}}"><i class="fas fa-circle-plus"></i></a>        
 
             </div>
 
@@ -308,7 +308,7 @@
 
                 <legend>
                     {{localize "WW.Talents.Traits"}}
-                    <a class="item-create" title="Create item" data-type="Trait or Talent" data-subtype="trait"><i class="fas fa-plus-circle"></i></a>
+                    <a class="item-create" data-tooltip="Create item" data-type="Trait or Talent" data-subtype="trait"><i class="fas fa-plus-circle"></i></a>
                 </legend>
 
                 <ol class="item-list described-list">
@@ -334,7 +334,7 @@
 
                 <legend>
                     {{localize "WW.Attack.Plural"}}
-                    <a class="item-create" title="Create item" data-type="Equipment" data-subtype="weapon"><i class="fas fa-plus-circle"></i></a>
+                    <a class="item-create" data-tooltip="Create item" data-type="Equipment" data-subtype="weapon"><i class="fas fa-plus-circle"></i></a>
                 </legend>
             
                 <ol class="item-list described-list">
@@ -351,7 +351,7 @@
 
                 <legend>
                     {{localize "WW.Talents.SpecialActions"}}
-                    <a class="item-create" title="Create item" data-type="Trait or Talent" data-subtype="action"><i class="fas fa-plus-circle"></i></a>
+                    <a class="item-create" data-tooltip="Create item" data-type="Trait or Talent" data-subtype="action"><i class="fas fa-plus-circle"></i></a>
                 </legend>
             
                 <ol class="item-list described-list">
@@ -366,7 +366,7 @@
 
         <div class="statbox-section">
 
-            <h6>{{localize "WW.Talents.Reactions"}}<a class="item-create ml-auto" title="Create item" data-type="Trait or Talent" data-subtype="reaction"><i
+            <h6>{{localize "WW.Talents.Reactions"}}<a class="item-create ml-auto" data-tooltip="Create item" data-type="Trait or Talent" data-subtype="reaction"><i
                 class="fas fa-plus"></i></a></h6>
             
             <ol class="item-list described-list">
@@ -379,7 +379,7 @@
         
         <div class="statbox-section">
 
-            <h6>{{localize "WW.Talents.Ends"}}<a class="item-create ml-auto" title="Create item" data-type="Trait or Talent" data-subtype="end"><i
+            <h6>{{localize "WW.Talents.Ends"}}<a class="item-create ml-auto" data-tooltip="Create item" data-type="Trait or Talent" data-subtype="end"><i
                 class="fas fa-plus"></i></a></h6>
             
             <ol class="item-list described-list">

--- a/templates/apps/combat-tracker.hbs
+++ b/templates/apps/combat-tracker.hbs
@@ -67,7 +67,7 @@
         </li>
         {{#each turns}}
         {{#if (and (eq this.type "Character") this.flags.weirdwizard.takingInit)}}
-        <li class="combatant actor directory-item flexrow{{#if this.flags.weirdwizard.acted}} acted{{/if}}{{#if this.injured}} injured{{/if}} {{this.css}}" title="{{localize "WW.Combat.Tip.RightClick"}}" data-combatant-id="{{this.id}}">
+        <li class="combatant actor directory-item flexrow{{#if this.flags.weirdwizard.acted}} acted{{/if}}{{#if this.injured}} injured{{/if}} {{this.css}}" data-tooltip="{{localize "WW.Combat.Tip.RightClick"}}" data-combatant-id="{{this.id}}">
             <img class="token-image" data-src="{{this.img}}" alt="{{this.name}}"/>
             <div class="token-name flexcol">
                 <h4>{{this.name}}</h4>
@@ -111,7 +111,7 @@
 
             {{!--<div class="combatant-acted">
                 
-                <a title="{{#if this.active}}{{localize "WW.Combat.ActingTip"}}
+                <a data-tooltip="{{#if this.active}}{{localize "WW.Combat.ActingTip"}}
                     {{else if this.flags.weirdwizard.acted}}{{localize "WW.Combat.ActedTip"}}
                     {{else}}{{localize "WW.Combat.ActTip"}}{{/if}}">
                     <i class="far {{#if this.active}}fa-stop
@@ -126,7 +126,7 @@
                 
                 {{#if this.owner}}
                     
-                    <a title="{{#if this.flags.weirdwizard.takingInit}}{{localize "WW.Combat.TurnTip"}}{{else}}{{localize "WW.Combat.InitiativeTip"}}{{/if}}">
+                    <a data-tooltip="{{#if this.flags.weirdwizard.takingInit}}{{localize "WW.Combat.TurnTip"}}{{else}}{{localize "WW.Combat.InitiativeTip"}}{{/if}}">
                         <i class="fas {{#if this.flags.weirdwizard.takingInit}}fa-hand-holding-magic{{else}}fa-wand-sparkles{{/if}}"></i></a>
                     
                 {{/if}}
@@ -141,7 +141,7 @@
         </li>
         {{#each turns}}
         {{#if (eq this.type "NPC")}}
-        <li class="combatant actor directory-item flexrow{{#if this.flags.weirdwizard.acted}} acted{{/if}}{{#if this.injured}} injured{{/if}} {{this.css}}" title="{{localize "WW.Combat.Tip.RightClick"}}" data-combatant-id="{{this.id}}">
+        <li class="combatant actor directory-item flexrow{{#if this.flags.weirdwizard.acted}} acted{{/if}}{{#if this.injured}} injured{{/if}} {{this.css}}" data-tooltip="{{localize "WW.Combat.Tip.RightClick"}}" data-combatant-id="{{this.id}}">
             <img class="token-image" data-src="{{this.img}}" alt="{{this.name}}"/>
             <div class="token-name flexcol">
                 <h4>{{this.name}}</h4>
@@ -187,7 +187,7 @@
             
             {{!--<div class="combatant-acted">
                 
-                <a title="{{#if this.active}}{{localize "WW.Combat.ActingTip"}}
+                <a data-tooltip="{{#if this.active}}{{localize "WW.Combat.ActingTip"}}
                     {{else if this.flags.weirdwizard.acted}}{{localize "WW.Combat.ActedTip"}}
                     {{else}}{{localize "WW.Combat.ActTip"}}{{/if}}">
                     <i class="far {{#if this.active}}fa-stop
@@ -203,7 +203,7 @@
                 
                 {{#if this.owner}}
                     
-                    <a title="{{#if this.flags.weirdwizard.takingInit}}{{localize "WW.Combat.TurnTip"}}{{else}}{{localize "WW.Combat.InitiativeTip"}}{{/if}}">
+                    <a data-tooltip="{{#if this.flags.weirdwizard.takingInit}}{{localize "WW.Combat.TurnTip"}}{{else}}{{localize "WW.Combat.InitiativeTip"}}{{/if}}">
                         <i class="fas {{#if this.flags.weirdwizard.takingInit}}fa-hand-holding-magic{{else}}fa-wand-sparkles{{/if}}"></i></a>
                     
                 {{/if}}
@@ -217,7 +217,7 @@
         </li>
         {{#each turns}}
         {{#if (and (eq this.type "Character") (not this.flags.weirdwizard.takingInit))}}
-        <li class="combatant actor directory-item flexrow{{#if this.flags.weirdwizard.acted}} acted{{/if}}{{#if this.injured}} injured{{/if}} {{this.css}}" title="{{localize "WW.Combat.Tip.RightClick"}}" data-combatant-id="{{this.id}}">
+        <li class="combatant actor directory-item flexrow{{#if this.flags.weirdwizard.acted}} acted{{/if}}{{#if this.injured}} injured{{/if}} {{this.css}}" data-tooltip="{{localize "WW.Combat.Tip.RightClick"}}" data-combatant-id="{{this.id}}">
             <img class="token-image" data-src="{{this.img}}" alt="{{this.name}}"/>
             <div class="token-name flexcol">
                 <h4>{{this.name}}</h4>
@@ -262,7 +262,7 @@
 
             {{!--<div class="combatant-acted">
                 
-                <a title="{{#if this.active}}{{localize "WW.Combat.ActingTip"}}
+                <a data-tooltip="{{#if this.active}}{{localize "WW.Combat.ActingTip"}}
                     {{else if this.flags.weirdwizard.acted}}{{localize "WW.Combat.ActedTip"}}
                     {{else}}{{localize "WW.Combat.ActTip"}}{{/if}}">
                     <i class="far {{#if this.active}}fa-stop
@@ -277,7 +277,7 @@
                 
                 {{#if this.owner}}
                     
-                    <a title="{{#if this.flags.weirdwizard.takingInit}}{{localize "WW.Combat.TurnTip"}}{{else}}{{localize "WW.Combat.InitiativeTip"}}{{/if}}">
+                    <a data-tooltip="{{#if this.flags.weirdwizard.takingInit}}{{localize "WW.Combat.TurnTip"}}{{else}}{{localize "WW.Combat.InitiativeTip"}}{{/if}}">
                         <i class="fas {{#if this.flags.weirdwizard.takingInit}}fa-hand-holding-magic{{else}}fa-wand-sparkles{{/if}}"></i></a>
                     
                 {{/if}}

--- a/templates/apps/roll-attribute.hbs
+++ b/templates/apps/roll-attribute.hbs
@@ -13,7 +13,7 @@
         {{#if attackBoons}}
         <div class="stat-stretch flex-group-left mt-1">
             <label class="resource-label">{{localize "WW.Boons.Attack"}}</label>
-            <input name="attack" class="damage-checkbox attack" type="checkbox" title="Apply boons/banes">
+            <input name="attack" class="damage-checkbox attack" type="checkbox" data-tooltip="Apply boons/banes">
             <span class="boons-display attack">{{numberFormat attackBoons decimals=0 sign=true}}</span>
         </div>
         {{/if}}

--- a/templates/apps/roll-damage.hbs
+++ b/templates/apps/roll-damage.hbs
@@ -5,14 +5,14 @@
 
         <div class="stat-stretch flex-group-left mt-1">
             <label class="resource-label">{{localize "WW.Damage.Base"}}</label>
-            <input name="applyBase" class="damage-checkbox applyBase" type="checkbox" title="Apply the base damage" checked="true">
+            <input name="applyBase" class="damage-checkbox applyBase" type="checkbox" data-tooltip="Apply the base damage" checked="true">
             +{{baseDamage}}
         </div>
 
         {{#if versatile}}
         <div class="stat-stretch flex-group-left mt-1">
             <label class="resource-label">{{localize "WW.Damage.BothHands"}}</label>
-            <input name="bothHands" class="damage-checkbox bothHands" type="checkbox" title="Apply the extra damage die">
+            <input name="bothHands" class="damage-checkbox bothHands" type="checkbox" data-tooltip="Apply the extra damage die">
             +1d6
         </div>
         {{/if}}
@@ -22,7 +22,7 @@
         {{#if bonusDamage}}
         <div class="stat-stretch flex-group-left mt-1">
             <label class="resource-label">{{localize "WW.Damage.Bonus"}}</label>
-            <input name="applyBonus" class="damage-checkbox applyBonus" type="checkbox" title="Apply all Bonus Damage dice">
+            <input name="applyBonus" class="damage-checkbox applyBonus" type="checkbox" data-tooltip="Apply all Bonus Damage dice">
             +{{bonusDamage}}d6
         </div>
         {{/if}}
@@ -30,7 +30,7 @@
         {{#if attackDice}}
         <div class="stat-stretch flex-group-left mt-1">
             <label class="resource-label">{{localize "WW.Damage.AttackDice"}}</label>
-            <input name="attackDice" class="damage-checkbox attackDice" type="checkbox" title="Apply the extra damage dice">
+            <input name="attackDice" class="damage-checkbox attackDice" type="checkbox" data-tooltip="Apply the extra damage dice">
             +{{attackDice}}d6
         </div>
         {{/if}}
@@ -38,7 +38,7 @@
         {{#if attackMod}}
         <div class="stat-stretch flex-group-left mt-1">
             <label class="resource-label">{{localize "WW.Damage.AttackMod"}}</label>
-            <input name="attackMod" class="damage-checkbox attackMod" type="checkbox" title="Apply the extra damage modifier">
+            <input name="attackMod" class="damage-checkbox attackMod" type="checkbox" data-tooltip="Apply the extra damage modifier">
             +{{attackMod}}
         </div>
         {{/if}}


### PR DESCRIPTION
This changes use of the HTML `title` attribute over to Foundry's `data-tooltip`. I've inspected each use and tested this locally. This should make no difference for now besides tooltips now looking minimally nicer and supporting formatting/markup.

