### PR TITLE
Use Foundry tooltips

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -166,6 +166,10 @@
 "WW.Item.Delete.NovicePath": "Remove Novice Path",
 "WW.Item.Delete.ExpertPath": "Remove Expert Path",
 "WW.Item.Delete.MasterPath": "Remove Master Path",
+"WW.Item.Delete.Weapon": "Remove Weapon",
+"WW.Item.Delete.Equipment": "Remove Equipment",
+"WW.Item.Delete.Spell": "Remove Spell",
+"WW.Item.Delete.Trait": "Remove Trait/Talent",
 
 "WW.Item.Delete.Dialog.Title": "Delete Item",
 "WW.Item.Delete.Dialog.Msg": "You are about to delete {name}. This action is irreversible.",
@@ -194,7 +198,18 @@
 "WW.Roll.CriticalSuccess": "Critical Success",
 "WW.Roll.Failure": "Failure",
 "WW.Roll.AutoFail": "Automatic Failure",
+"WW.Roll.Strength": "Roll Strength",
+"WW.Roll.Agility": "Roll Agility",
+"WW.Roll.Intellect": "Roll Intellect",
+"WW.Roll.Will": "Roll Will",
+"WW.Roll.Luck": "Roll Luck",
+"WW.Roll.ApplyBaseDamage": "Apply the base damage",
+"WW.Roll.ApplyExtraDamage": "Apply the extra damage die",
+"WW.Roll.ApplyExtraDamageDice": "Apply the extra damage dice",
+"WW.Roll.ApplyExtraDamageMod": "Apply the extra damage modifier",
+"WW.Roll.ApplyBonusDamage": "Apply all Bonus damage dice",
 
+"WW.Boons.Apply": "Apply boons/banes",
 "WW.Boons.Total": "Total Boons or Banes",
 "WW.Boons.Afflictions": "Boons/banes imposed by afflictions/effects",
 "WW.Boons.Attack": "Boons/banes to Attack rolls",
@@ -678,6 +693,8 @@
 "WW.System.Dialog.Save": "Save",
 "WW.System.Dialog.Reset": "Reset",
 "WW.System.Dialog.Cancel": "Cancel",
+
+"WW.System.EditImage": "Click to edit image",
 
 "WW.System.Migration.Started": "Outdated data found. Please wait until the data migration is finished.",
 "WW.System.Migration.Forced": "Forced data migration started. Please wait until the data migration is finished.",

--- a/module/chat/chat-listeners.mjs
+++ b/module/chat/chat-listeners.mjs
@@ -241,14 +241,14 @@ function _onMessageCollapse(ev) {
   
   // Flip states
   if (icon.hasClass('fa-square-plus')) {
-    $(button).attr("title", i18n('WW.Item.HideDesc'))
+    $(button).attr('data-tooltip', 'WW.Item.HideDesc')
     icon.removeClass('fa-square-plus').addClass('fa-square-minus');
     traits.slideDown(500);
     wrapper.slideDown(500);
     desc.slideDown(500);
     footer.slideDown(500);
   } else {
-    $(button).attr("title", i18n('WW.Item.ShowDesc'))
+    $(button).attr('data-tooltip', 'WW.Item.ShowDesc')
     icon.removeClass('fa-square-minus').addClass('fa-square-plus');
     traits.slideUp(500);
     wrapper.slideUp(500);

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -691,11 +691,11 @@ export default class WWActorSheet extends ActorSheet {
     
     // Flip states
     if (icon.hasClass('fa-square-chevron-down')) {
-      $(button).attr("title", i18n('WW.Item.HideDesc'))
+      $(button).attr('data-tooltip', 'WW.Item.HideDesc')
       icon.removeClass('fa-square-chevron-down').addClass('fa-square-chevron-up');
       desc.slideDown(500);
     } else {
-      $(button).attr("title", i18n('WW.Item.ShowDesc'))
+      $(button).attr('data-tooltip', 'WW.Item.ShowDesc')
       icon.removeClass('fa-square-chevron-up').addClass('fa-square-chevron-down');
       desc.slideUp(500);
     }

--- a/templates/actors/Character-sheet.hbs
+++ b/templates/actors/Character-sheet.hbs
@@ -16,13 +16,13 @@
             </div>
 
             <div class="circle" style="--total: 4">
-                <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="100" width="100"/>
+                <img class="profile-img" src="{{actor.img}}" data-edit="img" data-tooltip="WW.System.EditImage" height="100" width="100"/>
                 
                 <div class="stat" style="--i:1">
                     <label class="resource-label">{{localize "WW.Attributes.StrengthShort"}}</label>
                     <div>
                         <input type="number" name="system.attributes.str.value" value="{{system.attributes.str.value}}" min="0" data-dtype="Number"/>
-                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="str" title="Roll Strength">
+                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="str" data-tooltip="WW.Roll.Strength">
                             {{#if system.attributes.str.value}}
                             {{numberFormat system.attributes.str.mod decimals=0 sign=true}}
                             {{else}}—{{/if}}
@@ -34,7 +34,7 @@
                     <label class="resource-label">{{localize "WW.Attributes.AgilityShort"}}</label>
                     <div>
                         <input type="number" name="system.attributes.agi.value" value="{{system.attributes.agi.value}}" min="0" data-dtype="Number"/>
-                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="agi" title="Roll Agility">
+                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="agi" data-tooltip="WW.Roll.Agility">
                             {{#if system.attributes.agi.value}}
                             {{numberFormat system.attributes.agi.mod decimals=0 sign=true}}
                             {{else}}—{{/if}}
@@ -47,7 +47,7 @@
                     <label class="resource-label">{{localize "WW.Attributes.IntellectShort"}}</label>
                     <div>
                         <input type="number" name="system.attributes.int.value" value="{{system.attributes.int.value}}" min="0" data-dtype="Number"/>
-                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="int" title="Roll Intellect">
+                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="int" data-tooltip="WW.Roll.Intellect">
                             {{#if system.attributes.int.value}}
                             {{numberFormat system.attributes.int.mod decimals=0 sign=true}}
                             {{else}}—{{/if}}
@@ -59,7 +59,7 @@
                     <label class="resource-label">{{localize "WW.Attributes.WillShort"}}</label>
                     <div>
                         <input type="number" name="system.attributes.wil.value" value="{{system.attributes.wil.value}}" min="0" data-dtype="Number"/>
-                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="wil" title="Roll Will">
+                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="wil" data-tooltip="WW.Roll.Will">
                             {{#if system.attributes.wil.value}}
                             {{numberFormat system.attributes.wil.mod decimals=0 sign=true}}
                             {{else}}—{{/if}}
@@ -87,14 +87,14 @@
                     <div class="stat">
                         <label>{{localize "WW.Defense.Label"}}</label>
 
-                        <div><a title="{{localize "WW.Defense.Natural"}}: {{system.stats.defense.natural}}">{{system.stats.defense.total}}</a></div>
+                        <div><a data-tooltip="{{localize "WW.Defense.Natural"}}: {{system.stats.defense.natural}}">{{system.stats.defense.total}}</a></div>
                     </div>
 
                     {{!-- Health --}}
                     <div class="stat">
                         <label>{{localize "WW.Health.Label"}}</label>
 
-                        <div><a title="{{localize "WW.Health.Normal"}}: {{system.stats.health.normal}}. {{localize "WW.Health.Bonus"}}: {{system.stats.health.bonus}}. {{localize "WW.Health.Lost"}}: {{system.stats.health.lost}}">{{system.stats.health.current}}</a></div>
+                        <div><a data-tooltip="{{localize "WW.Health.Normal"}}: {{system.stats.health.normal}}. {{localize "WW.Health.Bonus"}}: {{system.stats.health.bonus}}. {{localize "WW.Health.Lost"}}: {{system.stats.health.lost}}">{{system.stats.health.current}}</a></div>
                     </div>
 
                     {{!-- Damage --}}
@@ -108,7 +108,7 @@
                                 <div class="input-overlay">{{system.stats.damage.value}}</div>
                             </div>
                             
-                            <i class="health-indicator fas {{#if incapacitated}}fa-octagon-xmark{{else if injured}}fa-droplet{{/if}}" title="
+                            <i class="health-indicator fas {{#if incapacitated}}fa-octagon-xmark{{else if injured}}fa-droplet{{/if}}" data-tooltip="
                                 {{#if incapacitated}}{{localize "WW.Health.Incapacitated"}}
                                 {{else}}{{localize "WW.Health.Injured"}}{{/if}}">
                             </i>
@@ -141,7 +141,7 @@
                         <div class="mr-2 luck">
                             <label>{{localize "WW.Attributes.Luck"}}</label>
 
-                            <div><a class="item-button resource-label" data-action="attribute-roll" data-key="luck" title="Roll {{localize "WW.Attributes.Luck"}}"><i class="large fas fa-dice-d20"></i></a></div>
+                            <div><a class="item-button resource-label" data-action="attribute-roll" data-key="luck" data-tooltip="WW.Roll.Luck"><i class="large fas fa-dice-d20"></i></a></div>
                         </div>
 
                         {{!-- Rest --}}

--- a/templates/actors/NPC-sheet.hbs
+++ b/templates/actors/NPC-sheet.hbs
@@ -6,7 +6,7 @@
         <div class="profile-img-wrapper">
             
             {{!-- Profile Image --}}
-            <img class="profile-img" src="{{actor.img}}" data-edit="img" title="{{actor.name}}"/>
+            <img class="profile-img" src="{{actor.img}}" data-edit="img" data-tooltip="WW.System.EditImage"/>
 
         </div>
 
@@ -17,7 +17,7 @@
                 <h1 class="charname"><input name="name" type="text" value="{{actor.name}}" placeholder="{{localize "WW.Actor.Name"}}"/></h1>
 
                 {{!-- Disposition Toggle --}}
-                <a class="change-disposition{{#if (eq disposition 1)}} ally{{/if}}" title="{{localize "WW.Actor.Disposition.Tip"}}">
+                <a class="change-disposition{{#if (eq disposition 1)}} ally{{/if}}" data-tooltip="WW.Actor.Disposition.Tip">
                     {{#if (eq disposition 1)}}{{localize "WW.Actor.Disposition.Ally"}}{{else}}{{localize "WW.Actor.Disposition.Enemy"}}{{/if}}
                 </a>
                 

--- a/templates/actors/parts/Character-effects.hbs
+++ b/templates/actors/parts/Character-effects.hbs
@@ -4,7 +4,7 @@
   {{#*inline "WWAffliction"}}
     <div class="affliction selectable {{#if value}}selected{{/if}}"
         style="width: auto; margin: 2px"
-        {{#if tooltip}}title="{{localize tooltip}}"{{/if}}>
+        {{#if tooltip}}data-tooltip="{{tooltip}}"{{/if}}>
       <input type="checkbox" id="data.{{name}}" data-name="{{name}}" {{checked value}}/>
       <i class="icon-{{name}}"></i>
       <span class="sep"></span>
@@ -89,7 +89,7 @@
       
       <div class="item-controls effect-controls flexrow">
         {{#if section.showCreate}}
-        <a class="effect-control" data-action="create" title="{{localize 'WW.Effect.Create'}}">
+        <a class="effect-control" data-action="create" data-tooltip="WW.Effect.Create">
           <i class="fas fa-plus"></i> {{localize "WW.Item.Add.Label"}}
         </a>
         {{/if}}
@@ -124,15 +124,15 @@
         <div class="item-controls effect-controls flexrow">
           {{#if (or (eq effect.parent.type 'Character') (eq effect.parent.type 'NPC'))}}
           {{#if (ne section.type 'temporary')}}
-          <a class="effect-control" data-action="toggle" title="{{localize 'WW.Effect.Toggle'}}">
+          <a class="effect-control" data-action="toggle" data-tooltip="WW.Effect.Toggle">
             <i class="fas {{#if effect.disabled}}fa-toggle-off{{else}}fa-toggle-on{{/if}}"></i>
           </a>
           {{/if}}
 
-          <a class="effect-control" data-action="edit" title="{{localize 'WW.Effect.Edit'}}">
+          <a class="effect-control" data-action="edit" data-tooltip="WW.Effect.Edit">
             <i class="fas fa-edit"></i>
           </a>
-          <a class="effect-control" data-action="delete" title="{{localize 'WW.Effect.Delete'}}">
+          <a class="effect-control" data-action="delete" data-tooltip="WW.Effect.Delete">
             <i class="fas fa-trash"></i>
           </a>
           {{/if}}
@@ -153,7 +153,7 @@
 
       <div class="item-controls effect-controls flexrow">
         {{#if actorEffects.inactive.showCreate}}
-        <a class="effect-control" data-action="create" title="{{localize 'WW.Effect.Create'}}">
+        <a class="effect-control" data-action="create" data-tooltip="WW.Effect.Create">
           <i class="fas fa-plus"></i> {{localize "WW.Item.Add.Label"}}
         </a>
         {{/if}}
@@ -187,14 +187,14 @@
         <div class="item-controls effect-controls flexrow">
           {{#if ../actorEffects.inactive.showControls}}
 
-          <a class="effect-control" data-action="toggle" title="{{localize 'WW.EffectToggle'}}">
+          <a class="effect-control" data-action="toggle" data-tooltip="WW.EffectToggle">
             <i class="fas {{#if effect.disabled}}fa-toggle-off{{else}}fa-toggle-on{{/if}}"></i>
           </a>
           
-          <a class="effect-control" data-action="edit" title="{{localize 'WW.EffectEdit'}}">
+          <a class="effect-control" data-action="edit" data-tooltip="WW.EffectEdit">
             <i class="fas fa-edit"></i>
           </a>
-          <a class="effect-control" data-action="delete" title="{{localize 'WW.EffectDelete'}}">
+          <a class="effect-control" data-action="delete" data-tooltip="WW.EffectDelete">
             <i class="fas fa-trash"></i>
           </a>
           {{/if}}

--- a/templates/actors/parts/Character-equipment.hbs
+++ b/templates/actors/parts/Character-equipment.hbs
@@ -63,7 +63,7 @@
             <div class="item-fixed">{{localize "WW.Weapon.Grip.Label"}}</div>
             <div class="item-traits">{{localize "WW.Weapon.Traits.Label"}}</div>
             <div class="item-controls">
-                <a class="item-control item-create" title="Create item" data-type="Equipment" data-subtype="weapon"><i
+                <a class="item-control item-create" data-tooltip="WW.Item.Add.Weapon" data-type="Equipment" data-subtype="weapon"><i
                     class="fas fa-plus"></i> {{localize "WW.Item.Add.Label"}}</a>
             </div>
         </li>
@@ -71,14 +71,14 @@
         {{#each weapons as |item id|}}
         <li class="item flexrow flex-group-left" data-item-id="{{item._id}}">
             {{!-- Icon --}}
-            <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
+            <div class="item-image"><img src="{{item.img}}" data-tooltip="WW.System.EditImage" width="24" height="24" /></div>
 
             <div class="item-name">
                 {{!-- Title --}}
                 {{#if item.needTargets}}<label class="item-button" data-action="targeted-use" data-item-id="{{item._id}}" 
-                    title="{{localize "WW.Targeting.AttackTargeted"}}">{{item.name}}</label>
+                    data-tooltip="WW.Targeting.AttackTargeted">{{item.name}}</label>
                 {{else if item.isActivity}}<label class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-                    title="{{localize "WW.Targeting.AttackUntargeted"}}">{{item.name}}</label>
+                    data-tooltip="WW.Targeting.AttackUntargeted">{{item.name}}</label>
                 {{else}}<label>{{item.name}}</label>{{/if}}
 
                 <span class="buttons">
@@ -87,12 +87,12 @@
 
                         {{#if item.needTargets}}
                         <a class="item-button" data-action="targeted-use" data-item-id="{{item._id}}"
-                            title="{{localize "WW.Targeting.AttackTargeted"}}">
+                            data-tooltip="WW.Targeting.AttackTargeted">
                         <i class="fas fa-bullseye"></i></a>
                         {{/if}}
 
                         <a class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-                            title="{{localize "WW.Targeting.AttackUntargeted"}}">
+                            data-tooltip="WW.Targeting.AttackUntargeted">
                         <i class="fas fa-bolt"></i></a>
 
                     {{/if}}
@@ -100,7 +100,7 @@
                     {{!-- Toggle Reloaded --}}
                     {{#if item.system.disadvantages.reload}}
                     <a class="item-button" data-action="item-toggle-reloaded" data-item-id="{{item._id}}"
-                        title="{{#if item.system.reloaded}}{{localize "WW.Weapon.Fire"}}{{else}}{{localize "WW.Weapon.Reload"}}{{/if}}">
+                        data-tooltip="{{#if item.system.reloaded}}{{localize "WW.Weapon.Fire"}}{{else}}{{localize "WW.Weapon.Reload"}}{{/if}}">
                     <i class="fas {{#if item.system.reloaded}}fa-hexagon-check{{else}}fa-arrows-rotate{{/if}}"></i></a>
                     {{/if}}
                     
@@ -120,11 +120,11 @@
             <div class="item-controls">              
                 {{!-- Edit Button --}}
                 <a class="item-button" data-action="item-edit" data-item-id="{{item._id}}"
-                    title="{{localize "WW.Item.Edit.Weapon"}}">
+                    data-tooltip="WW.Item.Edit.Weapon">
                 <i class="fas fa-edit"></i></a>
 
                 {{!-- Delete Button --}}
-                <a class="item-button" data-action="item-delete" data-item-id="{{item._id}}" title="Delete Item"><i class="fas fa-trash"></i></a>
+                <a class="item-button" data-action="item-delete" data-item-id="{{item._id}}" data-tooltip="WW.Item.Delete.Weapon"><i class="fas fa-trash"></i></a>
             </div>
         </li>
         {{/each}}
@@ -142,14 +142,14 @@
             <div class="item-uses">{{localize "WW.Equipment.Uses"}}</div>
             <div class="item-weight">{{localize "WW.Equipment.Weight"}}</div>
             <div class="item-controls">
-                <a class="item-control item-create" title="Create item" data-type="Equipment" data-subtype="generic"><i class="fas fa-plus"></i> {{localize "WW.Item.Add.Label"}}</a>
+                <a class="item-control item-create" data-tooltip="WW.Item.Add.Equipment" data-type="Equipment" data-subtype="generic"><i class="fas fa-plus"></i> {{localize "WW.Item.Add.Label"}}</a>
             </div>
         </li>
 
         {{#each equipment as |item id|}}
         <li class="item flexrow" data-item-id="{{item._id}}">
             {{!-- Icon --}}
-            <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
+            <div class="item-image"><img src="{{item.img}}" data-tooltip="WW.System.EditImage" width="24" height="24" /></div>
 
             {{!-- Quantity --}}
             <div class="item-quantity">{{item.system.quantity}}</div>
@@ -157,9 +157,9 @@
             <div class="item-name">
                 {{!-- Title --}}
                 {{#if item.needTargets}}<label class="item-button" data-action="targeted-use" data-item-id="{{item._id}}" 
-                    title="{{localize "WW.Targeting.EquipmentTargeted"}}">{{item.name}}</label>
+                    data-tooltip="WW.Targeting.EquipmentTargeted">{{item.name}}</label>
                 {{else if item.isActivity}}<label class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-                    title="{{localize "WW.Targeting.EquipmentUntargeted"}}">{{item.name}}</label>
+                    data-tooltip="WW.Targeting.EquipmentUntargeted">{{item.name}}</label>
                 {{else}}<label>{{item.name}}</label>{{/if}}
 
                 <span class="buttons">
@@ -168,12 +168,12 @@
 
                         {{#if item.needTargets}}
                         <a class="item-button" data-action="targeted-use" data-item-id="{{item._id}}"
-                            title="{{localize "WW.Targeting.EquipmentTargeted"}}">
+                            data-tooltip="WW.Targeting.EquipmentTargeted">
                         <i class="fas fa-bullseye"></i></a>
                         {{/if}}
 
                         <a class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-                            title="{{localize "WW.Targeting.EquipmentUntargeted"}}">
+                            data-tooltip="WW.Targeting.EquipmentUntargeted">
                         <i class="fas fa-bolt"></i></a>
 
                     {{/if}}
@@ -181,7 +181,7 @@
                     {{!-- Toggle Effects --}}
                     {{#if item.hasPassiveEffects}}
                         <a class="item-button" data-action="item-toggle-effects" data-item-id="{{item._id}}"
-                            title="{{#if item.system.active}}{{localize "WW.Item.DisableEffects"}}{{else}}{{localize "WW.Item.EnableEffects"}}{{/if}}">
+                            data-tooltip="{{#if item.system.active}}{{localize "WW.Item.DisableEffects"}}{{else}}{{localize "WW.Item.EnableEffects"}}{{/if}}">
                             <i class="fas {{#if item.system.active}}fa-toggle-on{{else}}fa-toggle-off{{/if}}"></i></a>
                     {{/if}}
 
@@ -200,7 +200,7 @@
                 <span class="pip-box">
                     {{#each item.uses as |pip id|}}
                     <a class="item-pip" data-item-id="{{item._id}}"
-                        title="{{#if (eq pip "far fa-circle")}}{{localize "WW.Item.Uses.EquipmentSpend"}}{{else}}{{localize "WW.Item.Uses.EquipmentRecover"}}{{/if}}">
+                        data-tooltip="{{#if (eq pip "far fa-circle")}}{{localize "WW.Item.Uses.EquipmentSpend"}}{{else}}{{localize "WW.Item.Uses.EquipmentRecover"}}{{/if}}">
                     <i class="{{pip}}"></i></a>
                     {{/each}}
                 </span>
@@ -213,11 +213,11 @@
             <div class="item-controls">              
                 {{!-- Edit Button --}}
                 <a class="item-button" data-action="item-edit" data-item-id="{{item._id}}"
-                    title="{{localize "WW.Item.Edit.Equipment"}}">
+                    data-tooltip="WW.Item.Edit.Equipment">
                 <i class="fas fa-edit"></i></a>
 
                 {{!-- Delete Button --}}
-                <a class="item-button" data-action="item-delete" data-item-id="{{item._id}}" title="Delete Item"><i class="fas fa-trash"></i></a>
+                <a class="item-button" data-action="item-delete" data-item-id="{{item._id}}" data-tooltip="WW.Item.Delete.Equipment"><i class="fas fa-trash"></i></a>
             </div>
         </li>
         {{/each}}

--- a/templates/actors/parts/Character-spells.hbs
+++ b/templates/actors/parts/Character-spells.hbs
@@ -8,10 +8,10 @@
                 
     <a data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
         <a class="array-button" data-action="edit" data-array="details.traditions" data-entry-id="{{id}}"
-            title="{{localize "WW.Traditions.Edit"}}"><i class="fas fa-edit"></i></a>
+            data-tooltip="WW.Traditions.Edit"><i class="fas fa-edit"></i></a>
                 
         <a class="array-button" data-action="remove" data-array="details.traditions" data-entry-id="{{id}}"
-            title="{{localize "WW.Traditions.Remove"}}"><i class="fas fa-trash"></i></a>
+            data-tooltip="WW.Traditions.Remove"><i class="fas fa-trash"></i></a>
 
         </span>{{#unless @last}},{{/unless}}
     </span>
@@ -19,7 +19,7 @@
                 
     {{#unless system.details.traditions.length}}—{{/unless}}
     <a class="array-button" data-action="add" data-array="details.traditions" data-loc="Traditions"
-        title="{{localize "WW.Traditions.Add"}}"><i class="fas fa-circle-plus"></i></a>            
+        data-tooltip="WW.Traditions.Add"><i class="fas fa-circle-plus"></i></a>            
             
 </div>
 
@@ -33,7 +33,7 @@
         <div>{{localize "WW.Item.Tier"}}</div>
         <div>{{localize "WW.Spell.Tradition"}}</div>
         <div class="item-controls">
-            <a class="item-control item-create" title="Create item" data-type="Spell"><i class="fas fa-plus"></i> {{localize "WW.Item.Add.Label"}}</a>
+            <a class="item-control item-create" data-tooltip="WW.Item.Add.Spell" data-type="Spell"><i class="fas fa-plus"></i> {{localize "WW.Item.Add.Label"}}</a>
         </div>
     </li>
 
@@ -41,15 +41,15 @@
     <li class="item flexrow" data-item-id="{{item._id}}">
 
         {{!-- Icon --}}
-        <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
+        <div class="item-image"><img src="{{item.img}}" data-tooltip="WW.System.EditImage" width="24" height="24" /></div>
 
         <div class="item-name">
             
             {{!-- Title --}}
             {{#if item.needTargets}}<label class="item-button" data-action="targeted-use" data-item-id="{{item._id}}"
-                title="{{localize "WW.Targeting.SpellTargeted"}}">{{item.name}}</label>
+                data-tooltip="WW.Targeting.SpellTargeted">{{item.name}}</label>
             {{else if item.isActivity}}<label class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-                title="{{localize "WW.Targeting.SpellUntargeted"}}">{{item.name}}</label>
+                data-tooltip="WW.Targeting.SpellUntargeted">{{item.name}}</label>
             {{else}}<label>{{item.name}}</label>{{/if}}
 
             <span class="buttons">
@@ -58,12 +58,12 @@
 
                     {{#if item.needTargets}}
                     <a class="item-button" data-action="targeted-use" data-item-id="{{item._id}}"
-                        title="{{localize "WW.Targeting.SpellTargeted"}}">
+                        data-tooltip="WW.Targeting.SpellTargeted">
                     <i class="fas fa-bullseye"></i></a>
                     {{/if}}
 
                     <a class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-                        title="{{localize "WW.Targeting.SpellUntargeted"}}">
+                        data-tooltip="WW.Targeting.SpellUntargeted">
                     <i class="fas fa-bolt"></i></a>
 
                 {{/if}}
@@ -71,7 +71,7 @@
                 {{!-- Toggle Effects --}}
                 {{#if item.hasPassiveEffects}}
                     <a class="item-button" data-action="item-toggle-effects" data-item-id="{{item._id}}"
-                        title="{{#if item.system.active}}{{localize "WW.Item.DisableEffects"}}{{else}}{{localize "WW.Item.EnableEffects"}}{{/if}}">
+                        data-tooltip="{{#if item.system.active}}{{localize "WW.Item.DisableEffects"}}{{else}}{{localize "WW.Item.EnableEffects"}}{{/if}}">
                         <i class="fas {{#if item.system.active}}fa-toggle-on{{else}}fa-toggle-off{{/if}}"></i></a>
                 {{/if}}
 
@@ -92,7 +92,7 @@
             <span class="pip-box">
                 {{#each item.uses as |pip id|}}
                 <a class="item-pip" data-item-id="{{item._id}}"
-                    title="{{#if (eq pip "far fa-circle")}}{{localize "WW.Item.Uses.SpellSpend"}}{{else}}{{localize "WW.Item.Uses.SpellRecover"}}{{/if}}">
+                    data-tooltip="{{#if (eq pip "far fa-circle")}}{{localize "WW.Item.Uses.SpellSpend"}}{{else}}{{localize "WW.Item.Uses.SpellRecover"}}{{/if}}">
                 <i class="{{pip}}"></i></a>
                 {{/each}}
             </span>
@@ -105,11 +105,11 @@
         <div class="item-controls">
             {{!-- Edit Button --}}
             <a class="item-button" data-action="item-edit" data-item-id="{{item._id}}"
-                title="{{localize "WW.Item.Edit.Spell"}}">
+                data-tooltip="WW.Item.Edit.Spell">
             <i class="fas fa-edit"></i></a>
 
             {{!-- Delete Button --}}
-            <a class="item-button" data-action="item-delete" data-item-id="{{item._id}}" title="Delete Item"><i class="fas fa-trash"></i></a>
+            <a class="item-button" data-action="item-delete" data-item-id="{{item._id}}" data-tooltip="WW.Item.Delete.Spell"><i class="fas fa-trash"></i></a>
         </div>
     </li>
     {{/each}}

--- a/templates/actors/parts/Character-summary-item.hbs
+++ b/templates/actors/parts/Character-summary-item.hbs
@@ -6,11 +6,11 @@
         <span class="compact-left">
             {{!-- Title --}}
             {{#if item.needTargets}}<label class="item-button" data-action="targeted-use" data-item-id="{{item._id}}"
-                title="{{#if (eq item.type "Trait or Talent")}}{{localize "WW.Targeting.TalentTargeted"}}
+                data-tooltip="{{#if (eq item.type "Trait or Talent")}}{{localize "WW.Targeting.TalentTargeted"}}
                     {{else if (eq item.type "Equipment")}}{{localize "WW.Targeting.EquipmentTargeted"}}
                     {{else if (eq item.type "Spell")}}{{localize "WW.Targeting.SpellTargeted"}}{{/if}}">{{item.name}}</label>
             {{else if item.isActivity}}<label class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-                title="{{#if (eq item.type "Trait or Talent")}}{{localize "WW.Targeting.TalentUntargeted"}}
+                data-tooltip="{{#if (eq item.type "Trait or Talent")}}{{localize "WW.Targeting.TalentUntargeted"}}
                     {{else if (eq item.type "Equipment")}}{{localize "WW.Targeting.EquipmentUntargeted"}}
                     {{else if (eq item.type "Spell")}}{{localize "WW.Targeting.SpellUntargeted"}}{{/if}}">{{item.name}}</label>
             {{else}}<label>{{item.name}}</label>{{/if}}
@@ -21,14 +21,14 @@
 
                     {{#if item.needTargets}}
                     <a class="item-button" data-action="targeted-use" data-item-id="{{item._id}}"
-                        title="{{#if (eq item.type "Trait or Talent")}}{{localize "WW.Targeting.TalentTargeted"}}
+                        data-tooltip="{{#if (eq item.type "Trait or Talent")}}{{localize "WW.Targeting.TalentTargeted"}}
                             {{else if (eq item.type "Equipment")}}{{localize "WW.Targeting.EquipmentTargeted"}}
                             {{else if (eq item.type "Spell")}}{{localize "WW.Targeting.SpellTargeted"}}{{/if}}">
                     <i class="fas fa-bullseye"></i></a>
                     {{/if}}
 
                     <a class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-                        title="{{#if (eq item.type "Trait or Talent")}}{{localize "WW.Targeting.TalentUntargeted"}}
+                        data-tooltip="{{#if (eq item.type "Trait or Talent")}}{{localize "WW.Targeting.TalentUntargeted"}}
                             {{else if (eq item.type "Equipment")}}{{localize "WW.Targeting.EquipmentUntargeted"}}
                             {{else if (eq item.type "Spell")}}{{localize "WW.Targeting.SpellUntargeted"}}{{/if}}">
                     <i class="fas fa-bolt"></i></a>
@@ -38,7 +38,7 @@
                 {{!-- Toggle Effects --}}
                 {{#if item.hasPassiveEffects}}
                     <a class="item-button" data-action="item-toggle-effects" data-item-id="{{item._id}}"
-                        title="{{#if item.system.active}}{{localize "WW.Item.DisableEffects"}}{{else}}{{localize "WW.Item.EnableEffects"}}{{/if}}">
+                        data-tooltip="{{#if item.system.active}}{{localize "WW.Item.DisableEffects"}}{{else}}{{localize "WW.Item.EnableEffects"}}{{/if}}">
                         <i class="fas {{#if item.system.active}}fa-toggle-on{{else}}fa-toggle-off{{/if}}"></i></a>
                 {{/if}}
 
@@ -47,7 +47,7 @@
                 <span class="pip-box">
                     {{#each item.uses as |pip id|}}
                     <a class="item-pip" data-item-id="{{../item._id}}"
-                        title="{{#if (eq pip "far fa-circle")}}
+                        data-tooltip="{{#if (eq pip "far fa-circle")}}
                             {{#if (eq ../item.type "Equipment")}}{{localize "WW.Item.Uses.EquipmentSpend"}}
                             {{else if (eq ../item.type "Spell")}}{{localize "WW.Item.Uses.SpellSpend"}}
                             {{else}}{{localize "WW.Item.Uses.TalentSpend"}}{{/if}}
@@ -67,16 +67,16 @@
         <span class="buttons">
             {{#if item.system.description.value}}
             {{!-- Send to Chat Scroll --}}
-            <a class="item-button" data-action="item-scroll" data-item-id="{{item._id}}" title="{{localize "WW.Item.Send"}}"><i
+            <a class="item-button" data-action="item-scroll" data-item-id="{{item._id}}" data-tooltip="WW.Item.Send"><i
                 class="far fa-scroll"></i></a>
             {{/if}}
 
             {{!-- Edit Button --}}
-            <a class="item-button" data-action="item-edit" data-item-id="{{item._id}}" title="{{localize (concat "WW.Item.Edit." item.type)}}"><i class="fas fa-edit"></i></a>
+            <a class="item-button" data-action="item-edit" data-item-id="{{item._id}}" data-tooltip="{{concat "WW.Item.Edit." item.type}}"><i class="fas fa-edit"></i></a>
 
             {{!-- Show/Hide Description (Collapse) --}}
             {{#if item.system.description.value}}
-            <a class="item-button" data-action="item-collapse" data-item-id="{{item._id}}" title="{{localize "WW.Item.ShowDesc"}}">
+            <a class="item-button" data-action="item-collapse" data-item-id="{{item._id}}" data-tooltip="WW.Item.ShowDesc">
                 <i class="fas fa-square-chevron-down"></i></a>
             {{/if}}
         </span>

--- a/templates/actors/parts/Character-summary-weapon.hbs
+++ b/templates/actors/parts/Character-summary-weapon.hbs
@@ -1,26 +1,26 @@
 <li class="item" data-item-id="{{item._id}}">
     {{!-- Title --}}
     {{#if item.needTargets}}<label class="item-button" data-action="targeted-use" data-item-id="{{item._id}}" 
-        title="{{localize "WW.Targeting.AttackTargeted"}}">{{item.name}}</label>
+        data-tooltip="WW.Targeting.AttackTargeted">{{item.name}}</label>
     {{else if item.isActivity}}<label class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-        title="{{localize "WW.Targeting.AttackUntargeted"}}">{{item.name}}</label>
+        data-tooltip="WW.Targeting.AttackUntargeted">{{item.name}}</label>
     {{else}}<label>{{item.name}}</label>{{/if}}
 
     <span class="buttons">
 
         {{!-- Use Buttons --}}
         <a class="item-button" data-action="targeted-use" data-item-id="{{item._id}}"
-            title="{{localize "WW.Targeting.AttackTargeted"}}">
+            data-tooltip="WW.Targeting.AttackTargeted">
         <i class="fas fa-bullseye"></i></a>
 
         <a class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-            title="{{localize "WW.Targeting.AttackUntargeted"}}">
+            data-tooltip="WW.Targeting.AttackUntargeted">
         <i class="fas fa-bolt"></i></a>
 
         {{!-- Toggle Reloaded --}}
         {{#if item.system.disadvantages.reload}}
         <a class="item-button" data-action="item-toggle-reloaded" data-item-id="{{item._id}}"
-            title="{{#if item.system.reloaded}}{{localize "WW.Weapon.Fire"}}{{else}}{{localize "WW.Weapon.Reload"}}{{/if}}">
+            data-tooltip="{{#if item.system.reloaded}}{{localize "WW.Weapon.Fire"}}{{else}}{{localize "WW.Weapon.Reload"}}{{/if}}">
         <i class="fas {{#if item.system.reloaded}}fa-hexagon-check{{else}}fa-arrows-rotate{{/if}}"></i></a>
         {{/if}}
         
@@ -33,7 +33,7 @@
 
         {{!-- Edit Button --}}
         <a class="item-button" data-action="item-edit" data-item-id="{{item._id}}"
-            title="{{localize "WW.Item.Edit.Weapon"}}">
+            data-tooltip="WW.Item.Edit.Weapon">
         <i class="fas fa-edit"></i></a>
     </span>
 

--- a/templates/actors/parts/Character-summary.hbs
+++ b/templates/actors/parts/Character-summary.hbs
@@ -12,15 +12,15 @@
                     <a data-tooltip="{{charOptions.ancestry.system.description.enriched}}">{{charOptions.ancestry.name}}</a>{{#if charOptions.ancestry}}<span class="buttons">
                     
                     <a class="item-button" data-action="item-edit" data-item-id="{{charOptions.ancestry._id}}"
-                        title="{{localize "WW.Item.Edit.Ancestry"}}"><i class="fas fa-edit"></i></a>
+                        data-tooltip="WW.Item.Edit.Ancestry"><i class="fas fa-edit"></i></a>
                     
                     <a class="item-button" data-action="item-delete" data-item-id="{{charOptions.ancestry._id}}"
-                        title="{{localize "WW.Item.Delete.Ancestry"}}"><i class="fas fa-trash"></i></a>
+                        data-tooltip="WW.Item.Delete.Ancestry"><i class="fas fa-trash"></i></a>
                     
                     </span>{{/if}}{{#unless charOptions.ancestry}}<span>—</span>
                     
                     {{!-- Create Button --}}
-                    <a class="item-control item-create" title="{{localize "WW.Item.Add.Ancestry"}}" data-type="Ancestry"><i
+                    <a class="item-control item-create" data-tooltip="WW.Item.Add.Ancestry" data-type="Ancestry"><i
                         class="fas fa-circle-plus"></i></a>
                     {{/unless}}
 
@@ -33,10 +33,10 @@
                     {{#if @first}}({{/if}}<a class="array-button" data-action="edit" data-array="details.descriptors" data-entry-id="{{id}}"
                         data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
                         <a class="array-button" data-action="edit" data-array="details.descriptors" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Descriptor.Edit"}}"><i class="fas fa-edit"></i></a>
+                            data-tooltip="WW.Detail.Descriptor.Edit"><i class="fas fa-edit"></i></a>
                 
                         <a class="array-button" data-action="remove" data-array="details.descriptors" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Descriptor.Remove"}}"><i class="fas fa-trash"></i></a>
+                            data-tooltip="WW.Detail.Descriptor.Remove"><i class="fas fa-trash"></i></a>
                     </span>{{#unless @last}},{{/unless}}{{#if @last}}){{/if}}
 
                 </span>
@@ -45,7 +45,7 @@
                 {{#unless system.details.descriptors.length}}<span class="hover-only">({{localize "WW.Detail.Descriptor.Label"}})</span>{{/unless}}
                 
                 <a class="array-button" data-action="add" data-array="details.descriptors" data-loc="Descriptor"
-                    title="{{localize "WW.Detail.Descriptor.Add"}}"><i class="fas fa-circle-plus"></i></a>
+                    data-tooltip="WW.Detail.Descriptor.Add"><i class="fas fa-circle-plus"></i></a>
                 
             </div>
 
@@ -75,23 +75,23 @@
                 {{!-- Speed --}}
                 <label class="ml-1">{{localize "WW.Stats.Speed"}}:</label>
 
-                <a class="mr-1" title="{{localize "WW.Stats.NormalSpeed"}}: {{system.stats.speed.normal}}">{{system.stats.speed.current}}</a>
+                <a class="mr-1" data-tooltip="{{localize "WW.Stats.NormalSpeed"}}: {{system.stats.speed.normal}}">{{system.stats.speed.current}}</a>
                 
                 {{!-- Movement Traits --}}
                 {{#each system.details.movementTraits as |detail id|}}<span class="list-entry">
                     {{#if @first}}({{/if}}<a class="array-button" data-action="edit" data-array="details.movementTraits" data-entry-id="{{id}}"
                         data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
                         <a class="array-button" data-action="edit" data-array="details.movementTraits" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Movement.Edit"}}"><i class="fas fa-edit"></i></a>
+                            data-tooltip="WW.Detail.Movement.Edit"><i class="fas fa-edit"></i></a>
                         
                         <a class="array-button" data-action="remove" data-array="details.movementTraits" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Movement.Remove"}}"><i class="fas fa-trash"></i></a>
+                            data-tooltip="WW.Detail.Movement.Remove"><i class="fas fa-trash"></i></a>
                     </span>{{#unless @last}},{{/unless}}{{#if @last}}){{/if}}
                 </span>
                 {{/each}}
 
                 <a class="array-button" data-action="add" data-array="details.movementTraits" data-loc="Movement"
-                    title="{{localize "WW.Detail.Movement.Add"}}"><i class="fas fa-circle-plus"></i></a>
+                    data-tooltip="WW.Detail.Movement.Add"><i class="fas fa-circle-plus"></i></a>
 
             </div>
         
@@ -109,15 +109,15 @@
                     <a data-tooltip="<p>{{localize "WW.Profession.Category"}}: {{localize item.system.categoryLoc}}</p><br/><p>{{item.system.description.enriched}}</p>">{{item.name}}</a><span class="buttons">
                         {{#if item.system.description.value}}
                         {{!-- Send to Chat Scroll --}}
-                        <a class="item-button" data-action="item-scroll" data-item-id="{{item._id}}" title="{{localize "WW.Item.Send"}}"><i
+                        <a class="item-button" data-action="item-scroll" data-item-id="{{item._id}}" data-tooltip="WW.Item.Send"><i
                             class="far fa-scroll"></i></a>
                         {{/if}}
 
                         {{!-- Edit Button --}}
-                        <a class="item-button" data-action="item-edit" data-item-id="{{item._id}}" title="{{localize (concat "WW.Item.Edit." item.type)}}"><i class="fas fa-edit"></i></a>
+                        <a class="item-button" data-action="item-edit" data-item-id="{{item._id}}" data-tooltip="{{concat "WW.Item.Edit." item.type}}"><i class="fas fa-edit"></i></a>
 
                         {{!-- Delete Button --}}
-                        <a class="item-button" data-action="item-delete" data-item-id="{{item._id}}" title="{{localize (concat "WW.Item.Delete." item.type)}}"><i class="fas fa-trash"></i></a>
+                        <a class="item-button" data-action="item-delete" data-item-id="{{item._id}}" data-tooltip="{{concat "WW.Item.Delete." item.type}}"><i class="fas fa-trash"></i></a>
                         
                     </span>{{#unless @last}},{{/unless}}
                     
@@ -127,7 +127,7 @@
                 {{#unless charOptions.professions.length}}<span>—</span>{{/unless}}
                     
                 {{!-- Create Button --}}
-                <a class="item-control item-create" title="{{localize "WW.Item.Add.Profession"}}" data-type="Profession"><i
+                <a class="item-control item-create" data-tooltip="WW.Item.Add.Profession" data-type="Profession"><i
                     class="fas fa-circle-plus"></i></a>
                 
             </div>
@@ -142,15 +142,15 @@
                     <a data-tooltip="{{charOptions.novice.system.description.enriched}}">{{charOptions.novice.name}}</a>{{#if charOptions.novice}}<span class="buttons">
                         
                         <a class="item-button" data-action="item-edit" data-item-id="{{charOptions.novice._id}}"
-                            title="{{localize "WW.Item.Edit.NovicePath"}}"><i class="fas fa-edit"></i></a>
+                            data-tooltip="WW.Item.Edit.NovicePath"><i class="fas fa-edit"></i></a>
                         
                         <a class="item-button" data-action="item-delete" data-item-id="{{charOptions.novice._id}}"
-                            title="{{localize "WW.Item.Delete.NovicePath"}}"><i class="fas fa-trash"></i></a>
+                            data-tooltip="WW.Item.Delete.NovicePath"><i class="fas fa-trash"></i></a>
                         
                     </span>{{/if}}{{#unless charOptions.novice}}<span>—</span>
                     
                     {{!-- Create Button --}}
-                    <a class="item-control item-create" title="{{localize "WW.Item.Add.NovicePath"}}" data-type="Path" data-tier="novice"><i
+                    <a class="item-control item-create" data-tooltip="WW.Item.Add.NovicePath" data-type="Path" data-tier="novice"><i
                         class="fas fa-circle-plus"></i></a>
                     {{/unless}}{{#if (gte system.stats.level 3)}},{{/if}}
                 </div>
@@ -162,15 +162,15 @@
                     <a data-tooltip="{{charOptions.expert.system.description.enriched}}">{{charOptions.expert.name}}</a>{{#if charOptions.expert}}<span class="buttons">
                         
                         <a class="item-button" data-action="item-edit" data-item-id="{{charOptions.expert._id}}"
-                            title="{{localize "WW.Item.Edit.ExpertPath"}}"><i class="fas fa-edit"></i></a>
+                            data-tooltip="WW.Item.Edit.ExpertPath"><i class="fas fa-edit"></i></a>
                         
                         <a class="item-button" data-action="item-delete" data-item-id="{{charOptions.expert._id}}"
-                            title="{{localize "WW.Item.Delete.ExpertPath"}}"><i class="fas fa-trash"></i></a>
+                            data-tooltip="WW.Item.Delete.ExpertPath"><i class="fas fa-trash"></i></a>
                         
                     </span>{{/if}}{{#unless charOptions.expert}}<span>—</span>
                     
                     {{!-- Create Button --}}
-                    <a class="item-control item-create" title="{{localize "WW.Item.Add.ExpertPath"}}" data-type="Path" data-tier="expert"><i
+                    <a class="item-control item-create" data-tooltip="WW.Item.Add.ExpertPath" data-type="Path" data-tier="expert"><i
                         class="fas fa-circle-plus"></i></a>
                     {{/unless}}{{#if (gte system.stats.level 7)}},{{/if}}
                 </div>
@@ -183,17 +183,17 @@
                     <a data-tooltip="{{charOptions.master.system.description.enriched}}">{{charOptions.master.name}}</a>{{#if charOptions.master}}<span class="buttons">
                         
                         <a class="item-button" data-action="item-edit" data-item-id="{{charOptions.master._id}}"
-                            title="{{localize "WW.Item.Edit.MasterPath"}}"><i class="fas fa-edit"></i></a>
+                            data-tooltip="WW.Item.Edit.MasterPath"><i class="fas fa-edit"></i></a>
                         
                         <a class="item-button" data-action="item-delete" data-item-id="{{charOptions.master._id}}"
-                            title="{{localize "WW.Item.Delete.MasterPath"}}"><i class="fas fa-trash"></i></a>
+                            data-tooltip="WW.Item.Delete.MasterPath"><i class="fas fa-trash"></i></a>
                         
                     </span>{{/if}}
 
                     {{#unless charOptions.master}}<span>—</span>
                     
                     {{!-- Create Button --}}
-                    <a class="item-control item-create" title="{{localize "WW.Item.Add.MasterPath"}}" data-type="Path" data-tier="master"><i
+                    <a class="item-control item-create" data-tooltip="WW.Item.Add.MasterPath" data-type="Path" data-tier="master"><i
                         class="fas fa-circle-plus"></i></a>
                     {{/unless}}
                     
@@ -213,10 +213,10 @@
                     <a class="array-button" data-action="edit" data-array="details.languages" data-entry-id="{{id}}"
                         data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
                         <a class="array-button" data-action="edit" data-array="details.languages" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Language.Edit"}}"><i class="fas fa-edit"></i></a>
+                            data-tooltip="WW.Detail.Language.Edit"><i class="fas fa-edit"></i></a>
                 
                         <a class="array-button" data-action="remove" data-array="details.languages" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Language.Remove"}}"><i class="fas fa-trash"></i></a>
+                            data-tooltip="WW.Detail.Language.Remove"><i class="fas fa-trash"></i></a>
                     </span>{{#unless @last}},{{/unless}}
                 </span>
                 {{/each}}
@@ -224,7 +224,7 @@
                 {{#unless system.details.languages.length}}<span>—</span>{{/unless}}
                 
                 <a class="array-button" data-action="add" data-array="details.languages" data-loc="Language"
-                    title="{{localize "WW.Detail.Language.Add"}}"><i class="fas fa-circle-plus"></i></a>
+                    data-tooltip="WW.Detail.Language.Add"><i class="fas fa-circle-plus"></i></a>
 
             </div>
 
@@ -238,10 +238,10 @@
                     <a class="array-button" data-action="edit" data-array="details.senses" data-entry-id="{{id}}"
                         data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
                         <a class="array-button" data-action="edit" data-array="details.senses" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Sense.Edit"}}"><i class="fas fa-edit"></i></a>
+                            data-tooltip="WW.Detail.Sense.Edit"><i class="fas fa-edit"></i></a>
                 
                         <a class="array-button" data-action="remove" data-array="details.senses" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Sense.Remove"}}"><i class="fas fa-trash"></i></a>
+                            data-tooltip="WW.Detail.Sense.Remove"><i class="fas fa-trash"></i></a>
                     </span>{{#unless @last}},{{/unless}}
 
                 </span>
@@ -250,7 +250,7 @@
                 {{#unless system.details.senses.length}}<span>—</span>{{/unless}}
                 
                 <a class="array-button" data-action="add" data-array="details.senses" data-loc="Sense"
-                    title="{{localize "WW.Detail.Sense.Add"}}"><i class="fas fa-circle-plus"></i></a>
+                    data-tooltip="WW.Detail.Sense.Add"><i class="fas fa-circle-plus"></i></a>
 
             </div>
 
@@ -265,10 +265,10 @@
                     <a class="array-button" data-action="edit" data-array="details.immune" data-entry-id="{{id}}"
                         data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
                         <a class="array-button" data-action="edit" data-array="details.immune" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Immune.Edit"}}"><i class="fas fa-edit"></i></a>
+                            data-tooltip="WW.Detail.Immune.Edit"><i class="fas fa-edit"></i></a>
                             
                         <a class="array-button" data-action="remove" data-array="details.immune" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Immune.Remove"}}"><i class="fas fa-trash"></i></a>
+                            data-tooltip="WW.Detail.Immune.Remove"><i class="fas fa-trash"></i></a>
                     </span>{{#unless @last}},{{/unless}}
 
                 </span>
@@ -277,7 +277,7 @@
                 {{#unless system.details.immune.length}}<span>—</span>{{/unless}}
 
                 <a class="array-button" data-action="add" data-array="details.immune" data-loc="Immune"
-                    title="{{localize "WW.Detail.Immune.Add"}}"><i class="fas fa-circle-plus"></i></a>        
+                    data-tooltip="WW.Detail.Immune.Add"><i class="fas fa-circle-plus"></i></a>        
 
             </div>
         </div>
@@ -358,10 +358,10 @@
                 <a class="array-button" data-action="edit" data-array="details.traditions" data-entry-id="{{id}}"
                     data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
                     <a class="array-button" data-action="edit" data-array="details.traditions" data-entry-id="{{id}}"
-                        title="{{localize "WW.Detail.Tradition.Edit"}}"><i class="fas fa-edit"></i></a>
+                        data-tooltip="WW.Detail.Tradition.Edit"><i class="fas fa-edit"></i></a>
                     
                     <a class="array-button" data-action="remove" data-array="details.traditions" data-entry-id="{{id}}"
-                        title="{{localize "WW.Detail.Tradition.Remove"}}"><i class="fas fa-trash"></i></a>
+                        data-tooltip="WW.Detail.Tradition.Remove"><i class="fas fa-trash"></i></a>
 
                     </span>{{#unless @last}},{{/unless}}
                 </span>
@@ -369,7 +369,7 @@
                     
                 {{#unless system.details.traditions.length}}<span>—</span>{{/unless}}
                 <a class="array-button" data-action="add" data-array="details.traditions" data-loc="Tradition"
-                    title="{{localize "WW.Detail.Tradition.Add"}}"><i class="fas fa-circle-plus"></i></a>            
+                    data-tooltip="WW.Detail.Tradition.Add"><i class="fas fa-circle-plus"></i></a>            
                 
             </div>
 

--- a/templates/actors/parts/Character-talents.hbs
+++ b/templates/actors/parts/Character-talents.hbs
@@ -7,7 +7,7 @@
         <div>{{localize "WW.Talent.Uses"}}</div>
         <div>{{localize "WW.Talent.Source.Label"}}</div>
         <div class="item-controls">
-            <a class="item-control item-create" title="Create item" data-type="Trait or Talent" data-subtype="trait" data-source="Ancestry"><i class="fas fa-plus"></i> {{localize "WW.Item.Add.Label"}}</a>
+            <a class="item-control item-create" data-tooltip="WW.Item.Add.Trait" data-type="Trait or Talent" data-subtype="trait" data-source="Ancestry"><i class="fas fa-plus"></i> {{localize "WW.Item.Add.Label"}}</a>
         </div>
     </li>
 
@@ -15,14 +15,14 @@
     <li class="item flexrow" data-item-id="{{item._id}}">
 
         {{!-- Icon --}}
-        <div class="item-image"><img src="{{item.img}}" title="{{item.name}}" width="24" height="24" /></div>
+        <div class="item-image"><img src="{{item.img}}" data-tooltip="WW.System.EditImage" width="24" height="24" /></div>
         
         <div class="item-name">
             {{!-- Title --}}
             {{#if item.needTargets}}<label class="item-button" data-action="targeted-use" data-item-id="{{item._id}}"
-                title="{{localize "WW.Targeting.TalentTargeted"}}">{{item.name}}</label>
+                data-tooltip="WW.Targeting.TalentTargeted">{{item.name}}</label>
             {{else if item.isActivity}}<label class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-                title="{{localize "WW.Targeting.TalentUntargeted"}}">{{item.name}}</label>
+                data-tooltip="WW.Targeting.TalentUntargeted">{{item.name}}</label>
             {{else}}<label>{{item.name}}</label>{{/if}}
 
             <span class="buttons">
@@ -31,12 +31,12 @@
 
                     {{#if item.needTargets}}
                     <a class="item-button" data-action="targeted-use" data-item-id="{{item._id}}"
-                        title="{{localize "WW.Targeting.TalentTargeted"}}">
+                        data-tooltip="WW.Targeting.TalentTargeted">
                     <i class="fas fa-bullseye"></i></a>
                     {{/if}}
                     
                     <a class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-                        title="{{localize "WW.Targeting.TalentUntargeted"}}">
+                        data-tooltip="WW.Targeting.TalentUntargeted">
                     <i class="fas fa-bolt"></i></a>
 
                 {{/if}}
@@ -44,7 +44,7 @@
                 {{!-- Toggle Effects --}}
                 {{#if item.hasPassiveEffects}}
                     <a class="item-button" data-action="item-toggle-effects" data-item-id="{{item._id}}"
-                        title="{{#if item.system.active}}{{localize "WW.Item.DisableEffects"}}{{else}}{{localize "WW.Item.EnableEffects"}}{{/if}}">
+                        data-tooltip="{{#if item.system.active}}{{localize "WW.Item.DisableEffects"}}{{else}}{{localize "WW.Item.EnableEffects"}}{{/if}}">
                         <i class="fas {{#if item.system.active}}fa-toggle-on{{else}}fa-toggle-off{{/if}}"></i></a>
                 {{/if}}
 
@@ -65,7 +65,7 @@
             <span class="pip-box">
                 {{#each item.uses as |pip id|}}
                 <a class="item-pip" data-item-id="{{item._id}}"
-                    title="{{#if (eq pip "far fa-circle")}}{{localize "WW.Item.Uses.TalentSpend"}}{{else}}{{localize "WW.Item.Uses.TalentRecover"}}{{/if}}">
+                    data-tooltip="{{#if (eq pip "far fa-circle")}}{{localize "WW.Item.Uses.TalentSpend"}}{{else}}{{localize "WW.Item.Uses.TalentRecover"}}{{/if}}">
                 <i class="{{pip}}"></i></a>
                 {{/each}}
             </span>
@@ -78,11 +78,11 @@
         <div class="item-controls">
             {{!-- Edit Button --}}
             <a class="item-button" data-action="item-edit" data-item-id="{{item._id}}"
-                title="{{localize "WW.Item.Edit.Talent"}}">
+                data-tooltip="WW.Item.Edit.Talent">
             <i class="fas fa-edit"></i></a>
 
             {{!-- Delete Button --}}
-            <a class="item-button" data-action="item-delete" data-item-id="{{item._id}}" title="Delete Item"><i class="fas fa-trash"></i></a>
+            <a class="item-button" data-action="item-delete" data-item-id="{{item._id}}" data-tooltip="WW.Item.Delete.Trait"><i class="fas fa-trash"></i></a>
         </div>
     </li>
     {{/each}}

--- a/templates/actors/parts/NPC-summary-item.hbs
+++ b/templates/actors/parts/NPC-summary-item.hbs
@@ -2,11 +2,11 @@
 
     {{!-- Title --}}
     {{#if item.needTargets}}<label class="item-button" data-action="targeted-use" data-item-id="{{item._id}}"
-        title="{{#if (eq item.type "Trait or Talent")}}{{localize "WW.Targeting.TalentTargeted"}}
+        data-tooltip="{{#if (eq item.type "Trait or Talent")}}{{localize "WW.Targeting.TalentTargeted"}}
             {{else if (eq item.type "Equipment")}}{{localize "WW.Targeting.EquipmentTargeted"}}
             {{else if (eq item.type "Spell")}}{{localize "WW.Targeting.SpellTargeted"}}{{/if}}">{{item.name}}:</label>
     {{else if item.isActivity}}<label class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-        title="{{#if (eq item.type "Trait or Talent")}}{{localize "WW.Targeting.TalentUntargeted"}}
+        data-tooltip="{{#if (eq item.type "Trait or Talent")}}{{localize "WW.Targeting.TalentUntargeted"}}
             {{else if (eq item.type "Equipment")}}{{localize "WW.Targeting.EquipmentUntargeted"}}
             {{else if (eq item.type "Spell")}}{{localize "WW.Targeting.SpellUntargeted"}}{{/if}}">{{item.name}}:</label>
     {{else}}<label>{{item.name}}:</label>{{/if}}
@@ -17,14 +17,14 @@
 
             {{#if item.needTargets}}
             <a class="item-button" data-action="targeted-use" data-item-id="{{item._id}}"
-                title="{{#if (eq item.type "Trait or Talent")}}{{localize "WW.Targeting.TalentTargeted"}}
+                data-tooltip="{{#if (eq item.type "Trait or Talent")}}{{localize "WW.Targeting.TalentTargeted"}}
                     {{else if (eq item.type "Equipment")}}{{localize "WW.Targeting.EquipmentTargeted"}}
                     {{else if (eq item.type "Spell")}}{{localize "WW.Targeting.SpellTargeted"}}{{/if}}">
             <i class="fas fa-bullseye"></i></a>
             {{/if}}
 
             <a class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-                title="{{#if (eq item.type "Trait or Talent")}}{{localize "WW.Targeting.TalentUntargeted"}}
+                data-tooltip="{{#if (eq item.type "Trait or Talent")}}{{localize "WW.Targeting.TalentUntargeted"}}
                     {{else if (eq item.type "Equipment")}}{{localize "WW.Targeting.EquipmentUntargeted"}}
                     {{else if (eq item.type "Spell")}}{{localize "WW.Targeting.SpellUntargeted"}}{{/if}}">
             <i class="fas fa-bolt"></i></a>
@@ -34,7 +34,7 @@
         {{!-- Toggle Effects --}}
         {{#if item.hasPassiveEffects}}
             <a class="item-button" data-action="item-toggle-effects" data-item-id="{{item._id}}"
-                title="{{#if item.system.active}}{{localize "WW.Item.DisableEffects"}}{{else}}{{localize "WW.Item.EnableEffects"}}{{/if}}">
+                data-tooltip="{{#if item.system.active}}{{localize "WW.Item.DisableEffects"}}{{else}}{{localize "WW.Item.EnableEffects"}}{{/if}}">
                 <i class="fas {{#if item.system.active}}fa-toggle-on{{else}}fa-toggle-off{{/if}}"></i></a>
         {{/if}}
 
@@ -43,7 +43,7 @@
         <span class="pip-box">
             {{#each item.uses as |pip id|}}
                 <a class="item-pip" data-item-id="{{../item._id}}"
-                    title="{{#if (eq pip "far fa-circle")}}
+                    data-tooltip="{{#if (eq pip "far fa-circle")}}
                         {{#if (eq ../item.system.subtype "action")}}{{localize "WW.Item.Uses.ActionSpend"}}
                         {{else if (eq ../item.system.subtype "reaction")}}{{localize "WW.Item.Uses.ActionSpend"}}
                         {{else if (eq ../item.system.subtype "fury")}}{{localize "WW.Item.Uses.FurySpend"}}
@@ -61,15 +61,15 @@
 
         {{!-- Send to Chat Scroll --}}
         {{#if item.system.description.value}}
-        <a class="item-button" data-action="item-scroll" data-item-id="{{item._id}}" title="{{localize "WW.Item.Send"}}"><i
+        <a class="item-button" data-action="item-scroll" data-item-id="{{item._id}}" data-tooltip="WW.Item.Send"><i
             class="far fa-scroll"></i></a>
         {{/if}}
 
         {{!-- Edit Button --}}
-        <a class="item-button" data-action="item-edit" data-item-id="{{item._id}}" title="{{localize (concat "WW.Item.Edit." item.type)}}"><i class="fas fa-edit"></i></a>
+        <a class="item-button" data-action="item-edit" data-item-id="{{item._id}}" data-tooltip="{{concat "WW.Item.Edit." item.type}}"><i class="fas fa-edit"></i></a>
         
         {{!-- Delete Button --}}
-        <a class="item-button" data-action="item-delete" data-item-id="{{item._id}}" title="Delete Item"><i class="fas fa-trash"></i></a>
+        <a class="item-button" data-action="item-delete" data-item-id="{{item._id}}" data-tooltip="{{concat "WW.Item.Delete." item.type}}"><i class="fas fa-trash"></i></a>
     </span>
     
     {{!-- Description --}}

--- a/templates/actors/parts/NPC-summary-weapon.hbs
+++ b/templates/actors/parts/NPC-summary-weapon.hbs
@@ -2,26 +2,26 @@
     
     {{!-- Title --}}
     {{#if item.needTargets}}<label class="item-button" data-action="targeted-use" data-item-id="{{item._id}}" 
-        title="{{localize "WW.Targeting.AttackTargeted"}}">{{item.label}}:</label>
+        data-tooltip="WW.Targeting.AttackTargeted">{{item.label}}:</label>
     {{else if item.isActivity}}<label class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-        title="{{localize "WW.Targeting.AttackUntargeted"}}">{{item.label}}:</label>
+        data-tooltip="WW.Targeting.AttackUntargeted">{{item.label}}:</label>
     {{else}}<label>{{item.name}}</label>{{/if}}
 
     <span class="buttons">
         
         {{!-- Use Buttons --}}
         <a class="item-button" data-action="targeted-use" data-item-id="{{item._id}}"
-            title="{{localize "WW.Targeting.AttackTargeted"}}">
+            data-tooltip="WW.Targeting.AttackTargeted">
         <i class="fas fa-bullseye"></i></a>
 
         <a class="item-button" data-action="untargeted-use" data-item-id="{{item._id}}"
-            title="{{localize "WW.Targeting.AttackUntargeted"}}">
+            data-tooltip="WW.Targeting.AttackUntargeted">
         <i class="fas fa-bolt"></i></a>
 
         {{!-- Toggle Reloaded --}}
         {{#if item.system.disadvantages.reload}}
         <a class="item-button" data-action="item-toggle-reloaded" data-item-id="{{item._id}}"
-            title="{{#if item.system.reloaded}}{{localize "WW.Weapon.Fire"}}{{else}}{{localize "WW.Weapon.Reload"}}{{/if}}">
+            data-tooltip="{{#if item.system.reloaded}}{{localize "WW.Weapon.Fire"}}{{else}}{{localize "WW.Weapon.Reload"}}{{/if}}">
         <i class="fas {{#if item.system.reloaded}}fa-hexagon-check{{else}}fa-arrows-rotate{{/if}}"></i></a>
         {{/if}}
         
@@ -34,12 +34,12 @@
 
         {{!-- Edit Button --}}
         <a class="item-button" data-action="item-edit" data-item-id="{{item._id}}"
-            title="{{localize "WW.Item.Edit.Attack"}}">
+            data-tooltip="WW.Item.Edit.Attack">
         <i class="fas fa-edit"></i></a>
 
         {{!-- Delete Button --}}
         <a class="item-button" data-action="item-delete" data-item-id="{{item._id}}"
-            title="{{localize "WW.Item.Delete.Title"}}">
+            data-tooltip="WW.Item.Delete.Title">
         <i class="fas fa-trash"></i></a>
     </span>
 

--- a/templates/actors/parts/NPC-summary.hbs
+++ b/templates/actors/parts/NPC-summary.hbs
@@ -14,10 +14,10 @@
                     <a class="array-button" data-action="edit" data-array="details.descriptors" data-entry-id="{{id}}"
                         data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
                         <a class="array-button" data-action="edit" data-array="details.descriptors" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Descriptor.Edit"}}"><i class="fas fa-edit"></i></a>
+                            data-tooltip="WW.Detail.Descriptor.Edit"><i class="fas fa-edit"></i></a>
                 
                         <a class="array-button" data-action="remove" data-array="details.descriptors" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Descriptor.Remove"}}"><i class="fas fa-trash"></i></a>
+                            data-tooltip="WW.Detail.Descriptor.Remove"><i class="fas fa-trash"></i></a>
                     </span>{{#unless @last}},{{/unless}}
 
                 </span>
@@ -26,7 +26,7 @@
                 {{#unless system.details.descriptors.length}}{{localize "WW.Detail.Descriptor.None"}}{{/unless}}
                 
                 <a class="array-button" data-action="add" data-array="details.descriptors" data-loc="Descriptor"
-                    title="{{localize "WW.Detail.Descriptor.Add"}}"><i class="fas fa-circle-plus"></i></a>
+                    data-tooltip="WW.Detail.Descriptor.Add"><i class="fas fa-circle-plus"></i></a>
 
             </span>
 
@@ -58,17 +58,17 @@
                 
                     {{#if system.stats.defense.details}}({{/if}}<input class="stat-edit" type="text"
                         name="system.stats.defense.details" value="{{system.stats.defense.details}}" data-dtype="String"
-                        title="{{localize "WW.Defense.Details"}}" />{{#if system.stats.defense.details}}){{/if}}
+                        data-tooltip="WW.Defense.Details" />{{#if system.stats.defense.details}}){{/if}}
                 </div>
 
                 {{!-- Health --}}
                 <div class="nowrap">
                     <label>{{localize "WW.Health.Label"}}:</label>
 
-                    <a title="{{localize "WW.Health.Bonus"}}: {{system.stats.health.bonus}}. {{localize "WW.Health.Lost"}}: {{system.stats.health.lost}}">{{system.stats.health.current}}</a>
+                    <a data-tooltip="{{localize "WW.Health.Bonus"}}: {{system.stats.health.bonus}}. {{localize "WW.Health.Lost"}}: {{system.stats.health.lost}}">{{system.stats.health.current}}</a>
                     
                     {{!-- <input type="number" name="system.stats.health.current" value="{{system.stats.health.current}}" min="0"
-                        data-dtype="Number" title="{{localize "WW.Health.Bonus"}}: {{system.stats.health.bonus}}. {{localize "WW.Health.Lost"}}: {{system.stats.health.lost}}"/> --}}
+                        data-dtype="Number" data-tooltip="{{localize "WW.Health.Bonus"}}: {{system.stats.health.bonus}}. {{localize "WW.Health.Lost"}}: {{system.stats.health.lost}}"/> --}}
 
                     <span class="stat-edit">
                         <label>{{localize "WW.Stats.Normal"}}:</label>
@@ -94,7 +94,7 @@
                         <div class="input-overlay">{{system.stats.damage.value}}</div>
                     </div>
 
-                    <i class="health-indicator fas {{#if incapacitated}}fa-octagon-xmark{{else if injured}}fa-droplet{{/if}}" title="
+                    <i class="health-indicator fas {{#if incapacitated}}fa-octagon-xmark{{else if injured}}fa-droplet{{/if}}" data-tooltip="
                         {{#if incapacitated}}{{localize "WW.Health.Incapacitated"}}
                         {{else}}{{localize "WW.Health.Injured"}}{{/if}}">
                     </i>
@@ -105,7 +105,7 @@
             <div class="mt-1 stat-inline">
 
                 {{!-- Strength --}}
-                <label><a class="item-button" data-action="attribute-roll" data-key="str" title="Roll Strength">{{localize "WW.Attributes.Strength"}}:</a></label>
+                <label><a class="item-button" data-action="attribute-roll" data-key="str" data-tooltip="WW.Roll.Strength">{{localize "WW.Attributes.Strength"}}:</a></label>
 
                 <div class="input-wrap">
                     <input type="number" name="system.attributes.str.value"
@@ -115,13 +115,13 @@
                 </div>
                     
                 {{#if system.attributes.str.value}}
-                <a class="attribute-mod item-button" data-action="attribute-roll" data-key="str" title="Roll Strength">
+                <a class="attribute-mod item-button" data-action="attribute-roll" data-key="str" data-tooltip="WW.Roll.Agility">
                     ({{numberFormat system.attributes.str.mod decimals=0 sign=true}})
                 </a>
                 {{/if}}
                 
                 {{!-- Agility --}}
-                <label class="ml-1"><a class="item-button" data-action="attribute-roll" data-key="agi" title="Roll Agility">{{localize "WW.Attributes.Agility"}}:</a></label>
+                <label class="ml-1"><a class="item-button" data-action="attribute-roll" data-key="agi" data-tooltip="WW.Roll.Agility">{{localize "WW.Attributes.Agility"}}:</a></label>
 
                 <div class="input-wrap">
                     <input type="number" name="system.attributes.agi.value"
@@ -131,7 +131,7 @@
                 </div>
                 
                 {{#if system.attributes.agi.value}}
-                <a class="attribute-mod item-button" data-action="attribute-roll" data-key="agi" title="Roll Agility">
+                <a class="attribute-mod item-button" data-action="attribute-roll" data-key="agi" data-tooltip="WW.Roll.Agility">
                     ({{numberFormat system.attributes.agi.mod decimals=0 sign=true}})
                 </a>
                 {{/if}}
@@ -142,7 +142,7 @@
             <div class="mt-1 stat-inline">
 
                 {{!-- Intellect --}}
-                <label><a class="item-button" data-action="attribute-roll" data-key="int" title="Roll Intellect">{{localize "WW.Attributes.Intellect"}}:</a></label>
+                <label><a class="item-button" data-action="attribute-roll" data-key="int" data-tooltip="WW.Roll.Intellect">{{localize "WW.Attributes.Intellect"}}:</a></label>
                 
                 <div class="input-wrap">
                     <input type="number" name="system.attributes.int.value"
@@ -152,13 +152,13 @@
                 </div>
                 
                 {{#if system.attributes.int.value}}
-                <a class="attribute-mod item-button" data-action="attribute-roll" data-key="int" title="Roll Intellect">
+                <a class="attribute-mod item-button" data-action="attribute-roll" data-key="int" data-tooltip="WW.Roll.Intellect">
                     ({{numberFormat system.attributes.int.mod decimals=0 sign=true}})
                 </a>
                 {{/if}}
                 
                 {{!-- Will --}}
-                <label class="ml-1"><a class="item-button" data-action="attribute-roll" data-key="wil" title="Roll Will">{{localize "WW.Attributes.Will"}}:</a></label>
+                <label class="ml-1"><a class="item-button" data-action="attribute-roll" data-key="wil" data-tooltip="WW.Roll.Will">{{localize "WW.Attributes.Will"}}:</a></label>
 
                 <div class="input-wrap">
                     <input type="number" name="system.attributes.wil.value"
@@ -168,7 +168,7 @@
                 </div>
                 
                 {{#if system.attributes.wil.value}}
-                <a class="attribute-mod item-button" data-action="attribute-roll" data-key="wil" title="Roll Will">
+                <a class="attribute-mod item-button" data-action="attribute-roll" data-key="wil" data-tooltip="WW.Roll.Will">
                     ({{numberFormat system.attributes.wil.mod decimals=0 sign=true}})
                 </a>
                 {{/if}}
@@ -206,16 +206,16 @@
                         data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
                         
                         <a class="array-button" data-action="edit" data-array="details.movementTraits" data-entry-id="{{id}}"
-                            title="{{localize "WW.Movement.Edit"}}"><i class="fas fa-edit"></i></a>
+                            data-tooltip="WW.Movement.Edit"><i class="fas fa-edit"></i></a>
                         
                         <a class="array-button" data-action="remove" data-array="details.movementTraits" data-entry-id="{{id}}"
-                            title="{{localize "WW.Movement.Remove"}}"><i class="fas fa-trash"></i></a>
+                            data-tooltip="WW.Movement.Remove"><i class="fas fa-trash"></i></a>
                     </span>{{#unless @last}},{{/unless}}{{#if @last}}){{/if}}
                 </span>
                 {{/each}}
 
                 <a class="array-button" data-action="add" data-array="details.movementTraits" data-loc="Movement"
-                    title="{{localize "WW.Movement.Add"}}"><i class="fas fa-circle-plus"></i></a>
+                    data-tooltip="WW.Movement.Add"><i class="fas fa-circle-plus"></i></a>
 
             </div>
             
@@ -235,10 +235,10 @@
                         data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
                         
                         <a class="array-button" data-action="edit" data-array="details.languages" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Language.Edit"}}"><i class="fas fa-edit"></i></a>
+                            data-tooltip="WW.Detail.Language.Edit"><i class="fas fa-edit"></i></a>
                 
                         <a class="array-button" data-action="remove" data-array="details.languages" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Language.Remove"}}"><i class="fas fa-trash"></i></a>
+                            data-tooltip="WW.Detail.Language.Remove"><i class="fas fa-trash"></i></a>
                     </span>{{#unless @last}},{{/unless}}
                 </span>
                 {{/each}}
@@ -246,7 +246,7 @@
                 {{#unless system.details.languages.length}}—{{/unless}}
                 
                 <a class="array-button" data-action="add" data-array="details.languages" data-loc="Language"
-                    title="{{localize "WW.Detail.Language.Add"}}"><i class="fas fa-circle-plus"></i></a>
+                    data-tooltip="WW.Detail.Language.Add"><i class="fas fa-circle-plus"></i></a>
 
             </div>
 
@@ -260,10 +260,10 @@
                     <a class="array-button" data-action="edit" data-array="details.senses" data-entry-id="{{id}}"
                         data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
                         <a class="array-button" data-action="edit" data-array="details.senses" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Sense.Edit"}}"><i class="fas fa-edit"></i></a>
+                            data-tooltip="WW.Detail.Sense.Edit"><i class="fas fa-edit"></i></a>
                 
                         <a class="array-button" data-action="remove" data-array="details.senses" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Sense.Remove"}}"><i class="fas fa-trash"></i></a>
+                            data-tooltip="WW.Detail.Sense.Remove"><i class="fas fa-trash"></i></a>
                     </span>{{#unless @last}},{{/unless}}
 
                 </span>
@@ -272,7 +272,7 @@
                 {{#unless system.details.senses.length}}—{{/unless}}
                 
                 <a class="array-button" data-action="add" data-array="details.senses" data-loc="Sense"
-                    title="{{localize "WW.Detail.Sense.Add"}}"><i class="fas fa-circle-plus"></i></a>
+                    data-tooltip="WW.Detail.Sense.Add"><i class="fas fa-circle-plus"></i></a>
 
             </div>
 
@@ -287,10 +287,10 @@
                     <a class="array-button" data-action="edit" data-array="details.immune" data-entry-id="{{id}}"
                         data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
                         <a class="array-button" data-action="edit" data-array="details.immune" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Immune.Edit"}}"><i class="fas fa-edit"></i></a>
+                            data-tooltip="WW.Detail.Immune.Edit"><i class="fas fa-edit"></i></a>
                             
                         <a class="array-button" data-action="remove" data-array="details.immune" data-entry-id="{{id}}"
-                            title="{{localize "WW.Detail.Immune.Remove"}}"><i class="fas fa-trash"></i></a>
+                            data-tooltip="WW.Detail.Immune.Remove"><i class="fas fa-trash"></i></a>
                     </span>{{#unless @last}},{{/unless}}
 
                 </span>
@@ -299,7 +299,7 @@
                 {{#unless system.details.immune.length}}—{{/unless}}
 
                 <a class="array-button" data-action="add" data-array="details.immune" data-loc="Immune"
-                    title="{{localize "WW.Detail.Immune.Add"}}"><i class="fas fa-circle-plus"></i></a>        
+                    data-tooltip="WW.Detail.Immune.Add"><i class="fas fa-circle-plus"></i></a>        
 
             </div>
 
@@ -308,7 +308,7 @@
 
                 <legend>
                     {{localize "WW.Talents.Traits"}}
-                    <a class="item-create" title="Create item" data-type="Trait or Talent" data-subtype="trait"><i class="fas fa-plus-circle"></i></a>
+                    <a class="item-create" data-tooltip="WW.Item.Add.Trait" data-type="Trait or Talent" data-subtype="trait"><i class="fas fa-plus-circle"></i></a>
                 </legend>
 
                 <ol class="item-list described-list">
@@ -334,7 +334,7 @@
 
                 <legend>
                     {{localize "WW.Attack.Plural"}}
-                    <a class="item-create" title="Create item" data-type="Equipment" data-subtype="weapon"><i class="fas fa-plus-circle"></i></a>
+                    <a class="item-create" data-tooltip="WW.Item.Add.Weapon" data-type="Equipment" data-subtype="weapon"><i class="fas fa-plus-circle"></i></a>
                 </legend>
             
                 <ol class="item-list described-list">
@@ -351,7 +351,7 @@
 
                 <legend>
                     {{localize "WW.Talents.SpecialActions"}}
-                    <a class="item-create" title="Create item" data-type="Trait or Talent" data-subtype="action"><i class="fas fa-plus-circle"></i></a>
+                    <a class="item-create" data-tooltip="WW.Item.Add.Trait" data-type="Trait or Talent" data-subtype="action"><i class="fas fa-plus-circle"></i></a>
                 </legend>
             
                 <ol class="item-list described-list">
@@ -366,7 +366,7 @@
 
         <div class="statbox-section">
 
-            <h6>{{localize "WW.Talents.Reactions"}}<a class="item-create ml-auto" title="Create item" data-type="Trait or Talent" data-subtype="reaction"><i
+            <h6>{{localize "WW.Talents.Reactions"}}<a class="item-create ml-auto" data-tooltip="WW.Item.Add.Trait" data-type="Trait or Talent" data-subtype="reaction"><i
                 class="fas fa-plus"></i></a></h6>
             
             <ol class="item-list described-list">
@@ -379,7 +379,7 @@
         
         <div class="statbox-section">
 
-            <h6>{{localize "WW.Talents.Ends"}}<a class="item-create ml-auto" title="Create item" data-type="Trait or Talent" data-subtype="end"><i
+            <h6>{{localize "WW.Talents.Ends"}}<a class="item-create ml-auto" data-tooltip="WW.Item.Add.Trait" data-type="Trait or Talent" data-subtype="end"><i
                 class="fas fa-plus"></i></a></h6>
             
             <ol class="item-list described-list">

--- a/templates/apps/combat-tracker.hbs
+++ b/templates/apps/combat-tracker.hbs
@@ -67,7 +67,7 @@
         </li>
         {{#each turns}}
         {{#if (and (eq this.type "Character") this.flags.weirdwizard.takingInit)}}
-        <li class="combatant actor directory-item flexrow{{#if this.flags.weirdwizard.acted}} acted{{/if}}{{#if this.injured}} injured{{/if}} {{this.css}}" title="{{localize "WW.Combat.Tip.RightClick"}}" data-combatant-id="{{this.id}}">
+        <li class="combatant actor directory-item flexrow{{#if this.flags.weirdwizard.acted}} acted{{/if}}{{#if this.injured}} injured{{/if}} {{this.css}}" data-tooltip="WW.Combat.Tip.RightClick" data-combatant-id="{{this.id}}">
             <img class="token-image" data-src="{{this.img}}" alt="{{this.name}}"/>
             <div class="token-name flexcol">
                 <h4>{{this.name}}</h4>
@@ -111,7 +111,7 @@
 
             {{!--<div class="combatant-acted">
                 
-                <a title="{{#if this.active}}{{localize "WW.Combat.ActingTip"}}
+                <a data-tooltip="{{#if this.active}}{{localize "WW.Combat.ActingTip"}}
                     {{else if this.flags.weirdwizard.acted}}{{localize "WW.Combat.ActedTip"}}
                     {{else}}{{localize "WW.Combat.ActTip"}}{{/if}}">
                     <i class="far {{#if this.active}}fa-stop
@@ -126,7 +126,7 @@
                 
                 {{#if this.owner}}
                     
-                    <a title="{{#if this.flags.weirdwizard.takingInit}}{{localize "WW.Combat.TurnTip"}}{{else}}{{localize "WW.Combat.InitiativeTip"}}{{/if}}">
+                    <a data-tooltip="{{#if this.flags.weirdwizard.takingInit}}{{localize "WW.Combat.TurnTip"}}{{else}}{{localize "WW.Combat.InitiativeTip"}}{{/if}}">
                         <i class="fas {{#if this.flags.weirdwizard.takingInit}}fa-hand-holding-magic{{else}}fa-wand-sparkles{{/if}}"></i></a>
                     
                 {{/if}}
@@ -141,7 +141,7 @@
         </li>
         {{#each turns}}
         {{#if (eq this.type "NPC")}}
-        <li class="combatant actor directory-item flexrow{{#if this.flags.weirdwizard.acted}} acted{{/if}}{{#if this.injured}} injured{{/if}} {{this.css}}" title="{{localize "WW.Combat.Tip.RightClick"}}" data-combatant-id="{{this.id}}">
+        <li class="combatant actor directory-item flexrow{{#if this.flags.weirdwizard.acted}} acted{{/if}}{{#if this.injured}} injured{{/if}} {{this.css}}" data-tooltip="WW.Combat.Tip.RightClick" data-combatant-id="{{this.id}}">
             <img class="token-image" data-src="{{this.img}}" alt="{{this.name}}"/>
             <div class="token-name flexcol">
                 <h4>{{this.name}}</h4>
@@ -187,7 +187,7 @@
             
             {{!--<div class="combatant-acted">
                 
-                <a title="{{#if this.active}}{{localize "WW.Combat.ActingTip"}}
+                <a data-tooltip="{{#if this.active}}{{localize "WW.Combat.ActingTip"}}
                     {{else if this.flags.weirdwizard.acted}}{{localize "WW.Combat.ActedTip"}}
                     {{else}}{{localize "WW.Combat.ActTip"}}{{/if}}">
                     <i class="far {{#if this.active}}fa-stop
@@ -203,7 +203,7 @@
                 
                 {{#if this.owner}}
                     
-                    <a title="{{#if this.flags.weirdwizard.takingInit}}{{localize "WW.Combat.TurnTip"}}{{else}}{{localize "WW.Combat.InitiativeTip"}}{{/if}}">
+                    <a data-tooltip="{{#if this.flags.weirdwizard.takingInit}}{{localize "WW.Combat.TurnTip"}}{{else}}{{localize "WW.Combat.InitiativeTip"}}{{/if}}">
                         <i class="fas {{#if this.flags.weirdwizard.takingInit}}fa-hand-holding-magic{{else}}fa-wand-sparkles{{/if}}"></i></a>
                     
                 {{/if}}
@@ -217,7 +217,7 @@
         </li>
         {{#each turns}}
         {{#if (and (eq this.type "Character") (not this.flags.weirdwizard.takingInit))}}
-        <li class="combatant actor directory-item flexrow{{#if this.flags.weirdwizard.acted}} acted{{/if}}{{#if this.injured}} injured{{/if}} {{this.css}}" title="{{localize "WW.Combat.Tip.RightClick"}}" data-combatant-id="{{this.id}}">
+        <li class="combatant actor directory-item flexrow{{#if this.flags.weirdwizard.acted}} acted{{/if}}{{#if this.injured}} injured{{/if}} {{this.css}}" data-tooltip="WW.Combat.Tip.RightClick" data-combatant-id="{{this.id}}">
             <img class="token-image" data-src="{{this.img}}" alt="{{this.name}}"/>
             <div class="token-name flexcol">
                 <h4>{{this.name}}</h4>
@@ -262,7 +262,7 @@
 
             {{!--<div class="combatant-acted">
                 
-                <a title="{{#if this.active}}{{localize "WW.Combat.ActingTip"}}
+                <a data-tooltip="{{#if this.active}}{{localize "WW.Combat.ActingTip"}}
                     {{else if this.flags.weirdwizard.acted}}{{localize "WW.Combat.ActedTip"}}
                     {{else}}{{localize "WW.Combat.ActTip"}}{{/if}}">
                     <i class="far {{#if this.active}}fa-stop
@@ -277,7 +277,7 @@
                 
                 {{#if this.owner}}
                     
-                    <a title="{{#if this.flags.weirdwizard.takingInit}}{{localize "WW.Combat.TurnTip"}}{{else}}{{localize "WW.Combat.InitiativeTip"}}{{/if}}">
+                    <a data-tooltip="{{#if this.flags.weirdwizard.takingInit}}{{localize "WW.Combat.TurnTip"}}{{else}}{{localize "WW.Combat.InitiativeTip"}}{{/if}}">
                         <i class="fas {{#if this.flags.weirdwizard.takingInit}}fa-hand-holding-magic{{else}}fa-wand-sparkles{{/if}}"></i></a>
                     
                 {{/if}}

--- a/templates/apps/quest-calendar-config.hbs
+++ b/templates/apps/quest-calendar-config.hbs
@@ -1,33 +1,33 @@
 <form class="weirdwizard quest-calendar">
 
-    <div class="qc-settings-row" title="{{localize "QC.Settings.PreciseSkipHint"}}">
+    <div class="qc-settings-row" data-tooltip="QC.Settings.PreciseSkipHint">
         <label>{{localize "QC.Settings.PreciseSkip"}}</label>
         <input type="checkbox" name="preciseSkip" {{checked preciseSkip}}>
     </div>
     
-    <div class="qc-settings-row" title="{{localize "QC.Settings.SkipRefHint"}}">
+    <div class="qc-settings-row" data-tooltip="QC.Settings.SkipRefHint">
         <label>{{localize "QC.Settings.SkipRef"}}</label>
         <select name="skipRef">
             {{selectOptions skipRefs selected=skipRef localize=true}}
         </select>
     </div>
 
-    <div class="qc-settings-row" title="{{localize "QC.Settings.SunriseHint"}}">
+    <div class="qc-settings-row" data-tooltip="QC.Settings.SunriseHint">
         <label>{{localize "QC.Settings.Sunrise"}}</label>
         <input type="number" name="sunrise" value="{{sunrise}}" min="0" max="23" />
     </div>
 
-    <div class="qc-settings-row" title="{{localize "QC.Settings.MiddayHint"}}">
+    <div class="qc-settings-row" data-tooltip="QC.Settings.MiddayHint">
         <label>{{localize "QC.Settings.Midday"}}</label>
         <input type="number" name="midday" value="{{midday}}" min="0" max="23" />
     </div>
 
-    <div class="qc-settings-row" title="{{localize "QC.Settings.SunsetHint"}}">
+    <div class="qc-settings-row" data-tooltip="QC.Settings.SunsetHint">
         <label>{{localize "QC.Settings.Sunset"}}</label>
         <input type="number" name="sunset" value="{{sunset}}" min="0" max="23" />
     </div>
 
-    <div class="qc-settings-row" title="{{localize "QC.Settings.MidnightHint"}}">
+    <div class="qc-settings-row" data-tooltip="QC.Settings.MidnightHint">
         <label>{{localize "QC.Settings.Midnight"}}</label>
         <input type="number" name="midnight" value="{{midnight}}" min="0" max="23" />
     </div>

--- a/templates/apps/quest-calendar.hbs
+++ b/templates/apps/quest-calendar.hbs
@@ -9,15 +9,15 @@
         </div>
 
         <div id="qc-hours-container">
-            <div id="qc-hour-prev" title="{{localize "QC.Menu.PrevHour"}}"><i class="fas fa-{{backward}}"></i></div>
-            <div id="qc-hour-round" title="{{localize "QC.Menu.RoundHour"}}"><i class="fas fa-arrows-rotate"></i></div>
-            <div id="qc-hour-next" title="{{localize "QC.Menu.NextHour"}}"><i class="fas fa-{{forward}}"></i></div>
-            <div id="qc-rest" title="{{localize "QC.Menu.Rest"}}"><i class="fas fa-bed"></i></div>
+            <div id="qc-hour-prev" data-tooltip="QC.Menu.PrevHour"><i class="fas fa-{{backward}}"></i></div>
+            <div id="qc-hour-round" data-tooltip="QC.Menu.RoundHour"><i class="fas fa-arrows-rotate"></i></div>
+            <div id="qc-hour-next" data-tooltip="QC.Menu.NextHour"><i class="fas fa-{{forward}}"></i></div>
+            <div id="qc-rest" data-tooltip="QC.Menu.Rest"><i class="fas fa-bed"></i></div>
             <div class="qc-space"></div>
-            <div id="qc-sunrise" title="{{localize "QC.Menu.Sunrise"}}"><i class="fas fa-sunrise"></i></div>
-            <div id="qc-midday" title="{{localize "QC.Menu.Midday"}}"><i class="fas fa-sun"></i></div>
-            <div id="qc-sunset" title="{{localize "QC.Menu.Sunset"}}"><i class="fas fa-sunset"></i></div>
-            <div id="qc-midnight" title="{{localize "QC.Menu.Midnight"}}"><i class="fas fa-moon"></i></div>
+            <div id="qc-sunrise" data-tooltip="QC.Menu.Sunrise"><i class="fas fa-sunrise"></i></div>
+            <div id="qc-midday" data-tooltip="QC.Menu.Midday"><i class="fas fa-sun"></i></div>
+            <div id="qc-sunset" data-tooltip="QC.Menu.Sunset"><i class="fas fa-sunset"></i></div>
+            <div id="qc-midnight" data-tooltip="QC.Menu.Midnight"><i class="fas fa-moon"></i></div>
         </div>
     </div>
 
@@ -35,8 +35,8 @@
                 </div>
 
                 <div class="qc-buttons">
-                    <div id="qc-month-prev" title="{{localize "QC.Calendar.MonthPrev"}}"><i class="fas fa-{{backward}}"></i></div>
-                    <div id="qc-month-next" title="{{localize "QC.Calendar.MonthNext"}}"><i class="fas fa-{{forward}}"></i></div>
+                    <div id="qc-month-prev" data-tooltip="QC.Calendar.MonthPrev"><i class="fas fa-{{backward}}"></i></div>
+                    <div id="qc-month-next" data-tooltip="QC.Calendar.MonthNext"><i class="fas fa-{{forward}}"></i></div>
                 </div>
             </div>
             
@@ -55,8 +55,8 @@
                 </div>
 
                 <div class="qc-buttons">
-                    <div id="qc-week-prev" title="{{localize "QC.Calendar.WeekPrev"}}"><i class="fas fa-{{backward}}"></i></div>
-                    <div id="qc-week-next" title="{{localize "QC.Calendar.WeekNext"}}"><i class="fas fa-{{forward}}"></i></div>
+                    <div id="qc-week-prev" data-tooltip="QC.Calendar.WeekPrev"><i class="fas fa-{{backward}}"></i></div>
+                    <div id="qc-week-next" data-tooltip="QC.Calendar.WeekNext"><i class="fas fa-{{forward}}"></i></div>
                 </div>
             </div>
             
@@ -73,8 +73,8 @@
                     {{#if (eq time.days 1)}}{{localize "QC.Calendar.Day"}}{{else}}{{localize "QC.Calendar.Days"}}{{/if}}
                 </div>
                 <div class="qc-buttons">
-                    <div id="qc-day-prev" title="{{localize "QC.Calendar.DayPrev"}}"><i class="fas fa-{{backward}}"></i></div>
-                    <div id="qc-day-next" title="{{localize "QC.Calendar.DayNext"}}"><i class="fas fa-{{forward}}"></i></div>
+                    <div id="qc-day-prev" data-tooltip="QC.Calendar.DayPrev"><i class="fas fa-{{backward}}"></i></div>
+                    <div id="qc-day-next" data-tooltip="QC.Calendar.DayNext"><i class="fas fa-{{forward}}"></i></div>
                 </div>
             </div>
             

--- a/templates/apps/roll-attribute.hbs
+++ b/templates/apps/roll-attribute.hbs
@@ -13,7 +13,7 @@
         {{#if attackBoons}}
         <div class="stat-stretch flex-group-left mt-1">
             <label class="resource-label">{{localize "WW.Boons.Attack"}}</label>
-            <input name="attack" class="damage-checkbox attack" type="checkbox" title="Apply boons/banes">
+            <input name="attack" class="damage-checkbox attack" type="checkbox" data-tooltip="WW.Boons.Apply">
             <span class="boons-display attack">{{numberFormat attackBoons decimals=0 sign=true}}</span>
         </div>
         {{/if}}

--- a/templates/apps/roll-damage.hbs
+++ b/templates/apps/roll-damage.hbs
@@ -5,14 +5,14 @@
 
         <div class="stat-stretch flex-group-left mt-1">
             <label class="resource-label">{{localize "WW.Damage.Base"}}</label>
-            <input name="applyBase" class="damage-checkbox applyBase" type="checkbox" title="Apply the base damage" checked="true">
+            <input name="applyBase" class="damage-checkbox applyBase" type="checkbox" data-tooltip="WW.Roll.ApplyBaseDamage" checked="true">
             +{{baseDamage}}
         </div>
 
         {{#if versatile}}
         <div class="stat-stretch flex-group-left mt-1">
             <label class="resource-label">{{localize "WW.Damage.BothHands"}}</label>
-            <input name="bothHands" class="damage-checkbox bothHands" type="checkbox" title="Apply the extra damage die">
+            <input name="bothHands" class="damage-checkbox bothHands" type="checkbox" data-tooltip="WW.Roll.ApplyExtraDamage">
             +1d6
         </div>
         {{/if}}
@@ -22,7 +22,7 @@
         {{#if bonusDamage}}
         <div class="stat-stretch flex-group-left mt-1">
             <label class="resource-label">{{localize "WW.Damage.Bonus"}}</label>
-            <input name="applyBonus" class="damage-checkbox applyBonus" type="checkbox" title="Apply all Bonus Damage dice">
+            <input name="applyBonus" class="damage-checkbox applyBonus" type="checkbox" data-tooltip="WW.Roll.ApplyBonusDamage">
             +{{bonusDamage}}d6
         </div>
         {{/if}}
@@ -30,7 +30,7 @@
         {{#if attackDice}}
         <div class="stat-stretch flex-group-left mt-1">
             <label class="resource-label">{{localize "WW.Damage.AttackDice"}}</label>
-            <input name="attackDice" class="damage-checkbox attackDice" type="checkbox" title="Apply the extra damage dice">
+            <input name="attackDice" class="damage-checkbox attackDice" type="checkbox" data-tooltip="WW.Roll.ApplyExtraDamageDice">
             +{{attackDice}}d6
         </div>
         {{/if}}
@@ -38,7 +38,7 @@
         {{#if attackMod}}
         <div class="stat-stretch flex-group-left mt-1">
             <label class="resource-label">{{localize "WW.Damage.AttackMod"}}</label>
-            <input name="attackMod" class="damage-checkbox attackMod" type="checkbox" title="Apply the extra damage modifier">
+            <input name="attackMod" class="damage-checkbox attackMod" type="checkbox" data-tooltip="WW.Roll.ApplyExtraDamageMod">
             +{{attackMod}}
         </div>
         {{/if}}

--- a/templates/chat/chat-message.hbs
+++ b/templates/chat/chat-message.hbs
@@ -33,7 +33,7 @@
         {{!-- Weapon Traits --}}
         <div class="traits-container">
             {{#each item.traits as |trait id|}}
-            <span class="header-button" title="{{trait.tip}}">{{trait.label}}</span>
+            <span class="header-button" data-tooltip="{{trait.tip}}">{{trait.label}}</span>
             {{/each}}
         </div>
 

--- a/templates/items/Equipment-sheet.hbs
+++ b/templates/items/Equipment-sheet.hbs
@@ -2,7 +2,7 @@
 
   {{!-- Header --}}
   <header class="sheet-header">
-    <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
+    <img class="profile-img" src="{{item.img}}" data-edit="img" data-tooltip="WW.System.EditImage"/>
 
     <div class="header-fields">
       <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize "WW.Item.Name"}}"/></h1>

--- a/templates/items/Spell-sheet.hbs
+++ b/templates/items/Spell-sheet.hbs
@@ -2,7 +2,7 @@
 
   {{!-- Header --}}
   <header class="sheet-header">
-    <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+    <img class="profile-img" src="{{item.img}}" data-edit="img" data-tooltip="WW.System.EditImage" />
     <div class="header-fields">
       <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize "WW.Item.Name"}}" /></h1>
 

--- a/templates/items/Trait or Talent-sheet.hbs
+++ b/templates/items/Trait or Talent-sheet.hbs
@@ -2,7 +2,7 @@
 
   {{!-- Header --}}
   <header class="sheet-header">
-    <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+    <img class="profile-img" src="{{item.img}}" data-edit="img" data-tooltip="WW.System.EditImage" />
     <div class="header-fields">
       <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize "WW.Item.Name"}}" /></h1>
 

--- a/templates/items/ancestry-sheet.hbs
+++ b/templates/items/ancestry-sheet.hbs
@@ -7,7 +7,7 @@
 
       {{!-- Header --}}
       <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
+        <img class="profile-img" src="{{item.img}}" data-edit="img" data-tooltip="WW.System.EditImage"/>
         <div class="header-fields">
           <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize "WW.Item.Name"}}"/></h1>
 
@@ -41,16 +41,16 @@
             
             <a data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
               <a class="array-button" data-action="edit" data-array="benefits.benefit1.descriptors" data-entry-id="{{id}}"
-                title="{{localize "WW.Detail.Descriptor.Edit"}}"><i class="fas fa-edit"></i></a>
+                data-tooltip="WW.Detail.Descriptor.Edit"><i class="fas fa-edit"></i></a>
             
               <a class="array-button" data-action="remove" data-array="benefits.benefit1.descriptors" data-entry-id="{{id}}"
-                title="{{localize "WW.Detail.Descriptor.Remove"}}"><i class="fas fa-trash"></i></a>
+                data-tooltip="WW.Detail.Descriptor.Remove"><i class="fas fa-trash"></i></a>
             </span>{{#unless @last}},{{/unless}}
           </span>
           {{/each}}{{#unless benefits.benefit1.descriptors.length}}<span>—</span>{{/unless}}
             
           <a class="array-button" data-action="add" data-array="benefits.benefit1.descriptors" data-loc="Descriptor"
-            title="{{localize "WW.Detail.Descriptor.Add"}}"><i class="fas fa-circle-plus"></i></a>
+            data-tooltip="WW.Detail.Descriptor.Add"><i class="fas fa-circle-plus"></i></a>
           
         </div>
 
@@ -63,16 +63,16 @@
             
             <a data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
               <a class="array-button" data-action="edit" data-array="benefits.benefit1.senses" data-entry-id="{{id}}"
-                title="{{localize "WW.Detail.Sense.Edit"}}"><i class="fas fa-edit"></i></a>
+                data-tooltip="WW.Detail.Sense.Edit"><i class="fas fa-edit"></i></a>
             
               <a class="array-button" data-action="remove" data-array="benefits.benefit1.senses" data-entry-id="{{id}}"
-                title="{{localize "WW.Detail.Sense.Remove"}}"><i class="fas fa-trash"></i></a>
+                data-tooltip="WW.Detail.Sense.Remove"><i class="fas fa-trash"></i></a>
             </span>{{#unless @last}},{{/unless}}
           </span>
           {{/each}}{{#unless benefits.benefit1.senses.length}}<span>—</span>{{/unless}}
             
           <a class="array-button" data-action="add" data-array="benefits.benefit1.senses" data-loc="Sense"
-            title="{{localize "WW.Detail.Sense.Add"}}"><i class="fas fa-circle-plus"></i></a>        
+            data-tooltip="WW.Detail.Sense.Add"><i class="fas fa-circle-plus"></i></a>        
           
         </div>
 
@@ -85,16 +85,16 @@
             
             <a data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
               <a class="array-button" data-action="edit" data-array="benefits.benefit1.languages" data-entry-id="{{id}}"
-                title="{{localize "WW.Detail.Language.Edit"}}"><i class="fas fa-edit"></i></a>
+                data-tooltip="WW.Detail.Language.Edit"><i class="fas fa-edit"></i></a>
             
               <a class="array-button" data-action="remove" data-array="benefits.benefit1.languages" data-entry-id="{{id}}"
-                title="{{localize "WW.Detail.Language.Remove"}}"><i class="fas fa-trash"></i></a>
+                data-tooltip="WW.Detail.Language.Remove"><i class="fas fa-trash"></i></a>
             </span>{{#unless @last}},{{/unless}}
           </span>
           {{/each}}{{#unless benefits.benefit1.languages.length}}<span>—</span>{{/unless}}
             
           <a class="array-button" data-action="add" data-array="benefits.benefit1.languages" data-loc="Language"
-            title="{{localize "WW.Detail.Language.Add"}}"><i class="fas fa-circle-plus"></i></a>
+            data-tooltip="WW.Detail.Language.Add"><i class="fas fa-circle-plus"></i></a>
 
         </div>
 
@@ -166,16 +166,16 @@
           {{#each benefits.benefit1.movementTraits as |detail id|}}<span class="list-entry">
             {{#if @first}}({{/if}}<a data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
               <a class="array-button" data-action="edit" data-array="benefits.benefit1.movementTraits" data-entry-id="{{id}}"
-                title="{{localize "WW.Movement.Edit"}}"><i class="fas fa-edit"></i></a>
+                data-tooltip="WW.Movement.Edit"><i class="fas fa-edit"></i></a>
             
               <a class="array-button" data-action="remove" data-array="benefits.benefit1.movementTraits" data-entry-id="{{id}}"
-                title="{{localize "WW.Movement.Remove"}}"><i class="fas fa-trash"></i></a>
+                data-tooltip="WW.Movement.Remove"><i class="fas fa-trash"></i></a>
             </span>{{#unless @last}},{{/unless}}{{#if @last}}){{/if}}
           </span>
           {{/each}}
             
           <a class="array-button" data-action="add" data-array="benefits.benefit1.movementTraits" data-loc="Movement"
-            title="{{localize "WW.Movement.Add"}}"><i class="fas fa-circle-plus"></i></a>
+            data-tooltip="WW.Movement.Add"><i class="fas fa-circle-plus"></i></a>
           
         </div>
 
@@ -188,10 +188,10 @@
             
             <a data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
               <a class="array-button" data-action="edit" data-array="benefits.benefit1.immune" data-entry-id="{{id}}"
-                title="{{localize "WW.Detail.Immune.Edit"}}"><i class="fas fa-edit"></i></a>
+                data-tooltip="WW.Detail.Immune.Edit"><i class="fas fa-edit"></i></a>
             
               <a class="array-button" data-action="remove" data-array="benefits.benefit1.immune" data-entry-id="{{id}}"
-                title="{{localize "WW.Detail.Immune.Remove"}}"><i class="fas fa-trash"></i></a>
+                data-tooltip="WW.Detail.Immune.Remove"><i class="fas fa-trash"></i></a>
             </span>{{#unless @last}},{{/unless}}
           </span>
           {{/each}}
@@ -199,7 +199,7 @@
           {{#unless benefits.benefit1.immune.length}}<span>—</span>{{/unless}}
             
           <a class="array-button" data-action="add" data-array="benefits.benefit1.immune" data-loc="Immune"
-            title="{{localize "WW.Detail.Immune.Add"}}"><i class="fas fa-circle-plus"></i></a>
+            data-tooltip="WW.Detail.Immune.Add"><i class="fas fa-circle-plus"></i></a>
             
           
 
@@ -214,9 +214,9 @@
             <label>{{item.name}}:</label>
       
             <span class="buttons">
-              {{#unless item.missing}}<a class="ref-edit" title="{{localize " WW.CharOption.EditRef"}}"><i
+              {{#unless item.missing}}<a class="ref-edit" data-tooltip="WW.CharOption.EditRef"><i
                   class="fas fa-edit"></i></a>{{/unless}}
-              <a class="ref-remove" title="{{localize " WW.CharOption.RemoveRef"}}"><i class="fas fa-trash"></i></a>
+              <a class="ref-remove" data-tooltip="WW.CharOption.RemoveRef"><i class="fas fa-trash"></i></a>
             </span>
       
             <span>{{{item.description}}}</span>

--- a/templates/items/parts/Equipment-details.hbs
+++ b/templates/items/parts/Equipment-details.hbs
@@ -17,7 +17,7 @@
             <div class="input-overlay">{{system.uses.max}}</div>
         </div>
 
-        <input class="checkbox-uses" type="checkbox" name="system.uses.onRest" {{checked system.uses.onRest}} title="{{localize "WW.Item.Uses.OnRest"}}"/>
+        <input class="checkbox-uses" type="checkbox" name="system.uses.onRest" {{checked system.uses.onRest}} data-tooltip="WW.Item.Uses.OnRest"/>
     </div>
 
     <div>

--- a/templates/items/parts/Talent-details.hbs
+++ b/templates/items/parts/Talent-details.hbs
@@ -20,7 +20,7 @@
             <div class="input-overlay">{{system.uses.max}}</div>
         </div>
         
-        <input class="checkbox-uses" type="checkbox" name="system.uses.onRest" {{checked system.uses.onRest}} title="{{localize "WW.Item.Uses.OnRest"}}"/>
+        <input class="checkbox-uses" type="checkbox" name="system.uses.onRest" {{checked system.uses.onRest}} data-tooltip="WW.Item.Uses.OnRest"/>
     </div>
 
 </div>

--- a/templates/items/parts/item-effects.hbs
+++ b/templates/items/parts/item-effects.hbs
@@ -9,7 +9,7 @@
         <div class="instant-effect-target">Target</div>
         <div class="instant-effect-value">Value</div>
         <div class="item-controls itemeffect-controls flexrow">
-            <a class="instant-control" data-action="create" title="{{localize 'WW.Effect.Create'}}">
+            <a class="instant-control" data-action="create" data-tooltip="WW.Effect.Create">
                 <i class="fas fa-plus"></i> {{localize "WW.Item.Add.Label"}}
             </a>
         </div>
@@ -36,10 +36,10 @@
                 {{/if}}
             </div>
             <div class="item-controls itemeffect-controls flexrow">
-                <a class="instant-control" data-action="edit" title="{{localize 'WW.Effect.Edit'}}">
+                <a class="instant-control" data-action="edit" data-tooltip="WW.Effect.Edit">
                     <i class="fas fa-edit"></i>
                 </a>
-                <a class="instant-control" data-action="delete" title="{{localize 'WW.Effect.Delete'}}">
+                <a class="instant-control" data-action="delete" data-tooltip="WW.Effect.Delete">
                     <i class="fas fa-trash"></i>
                 </a>
             </div>
@@ -59,7 +59,7 @@
         <div class="effect-changes">Changes</div>
         {{#if section.showDuration}}<div class="effect-duration">Duration</div>{{/if}}
         <div class="item-controls itemeffect-controls flexrow">
-            <a class="effect-control" data-action="create" title="{{localize 'WW.Effect.Create'}}">
+            <a class="effect-control" data-action="create" data-tooltip="WW.Effect.Create">
                 <i class="fas fa-plus"></i> {{localize "WW.Item.Add.Label"}}
             </a>
         </div>
@@ -83,14 +83,14 @@
                     {{else if (eq effect.trigger "onFailure")}}x
                     {{else if (eq effect.trigger "onUse")}}bolt
                     {{else}}gears
-                    {{/if}}" title="{{localize "WW.Effect.TriggerShort"}}: {{#if effect.locTrigger}}{{localize effect.locTrigger}}{{else}}{{localize "WW.Effect.Passive"}}{{/if}}"></i>
+                    {{/if}}" data-tooltip="{{localize "WW.Effect.TriggerShort"}}: {{#if effect.locTrigger}}{{localize effect.locTrigger}}{{else}}{{localize "WW.Effect.Passive"}}{{/if}}"></i>
 
                     <i class="fas fa-{{#if (eq effect.target "tokens")}}users
                     {{else if (eq effect.target "area")}}users-rectangle
                     {{else if (eq effect.target "areaAlly")}}users-rectangle color-green
                     {{else if (eq effect.target "areaEnemy")}}users-rectangle color-red
                     {{else}}user
-                    {{/if}}" title="{{localize "WW.Effect.Target"}}: {{#if effect.locTarget}}{{localize effect.locTarget}}{{else}}{{localize "WW.Effect.Passive"}}{{/if}}"></i>
+                    {{/if}}" data-tooltip="{{localize "WW.Effect.Target"}}: {{#if effect.locTarget}}{{localize effect.locTarget}}{{else}}{{localize "WW.Effect.Passive"}}{{/if}}"></i>
 
                 </span>
 
@@ -112,10 +112,10 @@
             {{#if section.showDuration}}<div class="effect-duration">{{effect.formattedDuration}}</div>{{/if}}
 
             <div class="item-controls itemeffect-controls flexrow">
-                <a class="effect-control" data-action="edit" title="{{localize 'WW.Effect.Edit'}}">
+                <a class="effect-control" data-action="edit" data-tooltip="WW.Effect.Edit">
                     <i class="fas fa-edit"></i>
                 </a>
-                <a class="effect-control" data-action="delete" title="{{localize 'WW.Effect.Delete'}}">
+                <a class="effect-control" data-action="delete" data-tooltip="WW.Effect.Delete">
                     <i class="fas fa-trash"></i>
                 </a>
             </div>

--- a/templates/items/parts/weapon-details.hbs
+++ b/templates/items/parts/weapon-details.hbs
@@ -44,7 +44,7 @@
         <label>{{localize "WW.Weapon.Traits.Label"}}</label>
         {{#each traits as |trait id|}}
         <div class="selectable {{#if (lookup @root.system.traits id)}}selected{{/if}}"
-            style="width: 100%" title="{{localize trait.tip}}">
+            style="width: 100%" data-tooltip="{{trait.tip}}">
 
             <input type="checkbox" name="system.traits.{{id}}" {{checked (lookup @root.system.traits id)}} />
 

--- a/templates/items/path-sheet.hbs
+++ b/templates/items/path-sheet.hbs
@@ -7,7 +7,7 @@
 
       {{!-- Header --}}
       <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}"/>
+        <img class="profile-img" src="{{item.img}}" data-edit="img" data-tooltip="WW.System.EditImage"/>
         <div class="header-fields">
           <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize "WW.Item.Name"}}"/></h1>
 
@@ -47,16 +47,16 @@
               
               <a data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
                 <a class="array-button" data-action="edit" data-array="benefits.{{id}}.languages" data-entry-id="{{detailId}}"
-                  title="{{localize "WW.Detail.Language.Edit"}}"><i class="fas fa-edit"></i></a>
+                  data-tooltip="WW.Detail.Language.Edit"><i class="fas fa-edit"></i></a>
               
                 <a class="array-button" data-action="remove" data-array="benefits.{{id}}.languages" data-entry-id="{{detailId}}"
-                  title="{{localize "WW.Detail.Language.Remove"}}"><i class="fas fa-trash"></i></a>
+                  data-tooltip="WW.Detail.Language.Remove"><i class="fas fa-trash"></i></a>
               </span>{{#unless @last}},{{/unless}}
             </span>
             {{/each}}{{#unless benefit.languages.length}}<span>—</span>{{/unless}}
               
             <a class="array-button" data-action="add" data-array="benefits.{{id}}.languages" data-loc="Language"
-              title="{{localize "WW.Detail.Language.Add"}}"><i class="fas fa-circle-plus"></i></a>
+              data-tooltip="WW.Detail.Language.Add"><i class="fas fa-circle-plus"></i></a>
 
           </div>
 
@@ -177,16 +177,16 @@
               
                 <a data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
                   <a class="array-button" data-action="edit" data-array="benefits.{{id}}.traditions" data-entry-id="{{detailId}}"
-                    title="{{localize "WW.Detail.Tradition.Edit"}}"><i class="fas fa-edit"></i></a>
+                    data-tooltip="WW.Detail.Tradition.Edit"><i class="fas fa-edit"></i></a>
               
                   <a class="array-button" data-action="remove" data-array="benefits.{{id}}.traditions" data-entry-id="{{detailId}}"
-                    title="{{localize "WW.Detail.Tradition.Remove"}}"><i class="fas fa-trash"></i></a>
+                    data-tooltip="WW.Detail.Tradition.Remove"><i class="fas fa-trash"></i></a>
                 </span>{{#unless @last}},{{/unless}}
               </span>
               {{/each}}{{#unless benefit.traditions.length}}<span>—</span>{{/unless}}
               
               <a class="array-button" data-action="add" data-array="benefits.{{id}}.traditions" data-loc="Tradition"
-                title="{{localize "WW.Detail.Tradition.Add"}}"><i class="fas fa-circle-plus"></i></a>
+                data-tooltip="WW.Detail.Tradition.Add"><i class="fas fa-circle-plus"></i></a>
 
               {{!-- Spells --}}
               <label>{{localize "WW.Spells.Label"}}:</label>
@@ -212,8 +212,8 @@
               <label>{{item.name}}:</label>
 
               <span class="buttons">
-                {{#unless item.missing}}<a class="ref-edit" title="{{localize "WW.CharOption.EditRef"}}"><i class="fas fa-edit"></i></a>{{/unless}}
-                <a class="ref-remove" title="{{localize "WW.CharOption.RemoveRef"}}"><i class="fas fa-trash"></i></a>
+                {{#unless item.missing}}<a class="ref-edit" data-tooltip="WW.CharOption.EditRef"><i class="fas fa-edit"></i></a>{{/unless}}
+                <a class="ref-remove" data-tooltip="WW.CharOption.RemoveRef"><i class="fas fa-trash"></i></a>
               </span>
 
               <span>{{{item.description}}}</span>

--- a/templates/items/profession-sheet.hbs
+++ b/templates/items/profession-sheet.hbs
@@ -2,7 +2,7 @@
 
   {{!-- Header --}}
   <header class="sheet-header">
-    <img class="profile-img" src="{{item.img}}" data-edit="img" title="{{item.name}}" />
+    <img class="profile-img" src="{{item.img}}" data-edit="img" data-tooltip="WW.System.EditImage" />
     <div class="header-fields">
       <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize "WW.Item.Name"}}" /></h1>
   
@@ -39,16 +39,16 @@
       
         <a data-tooltip="{{detail.desc}}">{{detail.name}}</a><span class="buttons">
           <a class="array-button" data-action="edit" data-array="benefits.benefit1.languages" data-entry-id="{{id}}"
-            title="{{localize "WW.Detail.Language.Edit"}}"><i class="fas fa-edit"></i></a>
+            data-tooltip="WW.Detail.Language.Edit"><i class="fas fa-edit"></i></a>
       
           <a class="array-button" data-action="remove" data-array="benefits.benefit1.languages" data-entry-id="{{id}}"
-            title="{{localize "WW.Detail.Language.Remove"}}"><i class="fas fa-trash"></i></a>
+            data-tooltip="WW.Detail.Language.Remove"><i class="fas fa-trash"></i></a>
         </span>{{#unless @last}},{{/unless}}
       </span>
       {{/each}}{{#unless benefits.benefit1.languages.length}}<span>—</span>{{/unless}}
       
       <a class="array-button" data-action="add" data-array="benefits.benefit1.languages" data-loc="Language"
-        title="{{localize "WW.Detail.Language.Add"}}"><i class="fas fa-circle-plus"></i></a>
+        data-tooltip="WW.Detail.Language.Add"><i class="fas fa-circle-plus"></i></a>
   
     </div>
   
@@ -61,9 +61,9 @@
         <label>{{item.name}}:</label>
   
         <span class="buttons">
-          {{#unless item.missing}}<a class="ref-edit" title="{{localize " WW.CharOption.EditRef"}}"><i
+          {{#unless item.missing}}<a class="ref-edit" data-tooltip="WW.CharOption.EditRef"><i
               class="fas fa-edit"></i></a>{{/unless}}
-          <a class="ref-remove" title="{{localize " WW.CharOption.RemoveRef"}}"><i class="fas fa-trash"></i></a>
+          <a class="ref-remove" data-tooltip="WW.CharOption.RemoveRef"><i class="fas fa-trash"></i></a>
         </span>
   
         <span>{{{item.description}}}</span>


### PR DESCRIPTION
This updates all tooltips from the standard HTML `title` attribute to Foundry's own `data-tooltip`.
This allows us to use markup and styling for tooltips in the future, and also already supports localization, so we can drop all the `localize`/`i18n` calls.

A few tooltips were still hardcoded and missing translation strings; while moving them over, I added them in this PR.

First step towards https://github.com/Savantford/foundry-weirdwizard/issues/150.