### PR TITLE
Pretty up the settings sidebar system version

### DIFF
--- a/module/weirdwizard.mjs
+++ b/module/weirdwizard.mjs
@@ -367,6 +367,31 @@ Hooks.on('renderSettingsConfig', (app, html, data) => {
   });
 });
 
+// Pretty up the system version display in the settings sidebar.
+Hooks.on("renderSettings", (app, [html]) => {
+  const details = html.querySelector("#game-details");
+  const pip = details.querySelector(".system-info .update");
+  details.querySelector(".system").remove();
+
+  const heading = document.createElement("div");
+  heading.classList.add("weirdwizard", "sidebar-heading");
+  heading.innerHTML = `<h2>${game.i18n.localize("WORLD.GameSystem")}</h2>`;
+  details.insertAdjacentElement("afterend", heading);
+
+  const badge = document.createElement("div");
+  badge.classList.add("weirdwizard", "system-badge");
+  badge.innerHTML = `
+    <img src="systems/weirdwizard/assets/ui/sotww-logo.png" data-tooltip="${game.system.title}" alt="${game.system.title}">
+    <p class="system-info" style="text-align: center;">${game.system.title} Version ${game.system.version}<br>
+        <a href="https://github.com/Savantford/foundry-weirdwizard/releases/latest" target="_blank">Patchnotes</a> •
+        <a href="https://github.com/Savantford/foundry-weirdwizard/issues" target="_blank">Issues</a> •
+        <a href="https://discord.com/invite/DUMfrUc" target="_blank">Discord</a>
+    </p>
+  `;
+  if (pip) badge.querySelector(".system-info").insertAdjacentElement("beforeend", pip);
+  heading.insertAdjacentElement("afterend", badge);
+});
+
 /* -------------------------------------------- */
 /*  External Module Hooks                       */
 /* -------------------------------------------- */


### PR DESCRIPTION
Functionally, this adds direct links to the SotWW Changelog, Github Issues and Discord to the settings sidebar tab.

# Before

![before](https://github.com/Savantford/foundry-weirdwizard/assets/1654763/4826c40e-050b-4542-9eb0-dc5b356d099f)


# After

![after](https://github.com/Savantford/foundry-weirdwizard/assets/1654763/3bd75ec5-87d9-4efc-87b0-baa5f27d7810)

Inspired with ❤️ by the 5E system.