### PR TITLE
Fix resting breaking on actors with some items

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -843,7 +843,7 @@ export default class WWActorSheet extends ActorSheet {
     });
 
     // Recover uses/tokens/castings for Talents and Spells
-    this.actor.updateEmbeddedDocuments('Item', this.actor.items.filter(i => i.system.uses.onRest === true).map(i => ({ _id: i.id, 'system.uses.value': 0 })));
+    this.actor.updateEmbeddedDocuments('Item', this.actor.items.filter(i => i.system.uses?.onRest === true).map(i => ({ _id: i.id, 'system.uses.value': 0 })));
 
     // Send message to chat
     let messageData = {


### PR DESCRIPTION
For me, for some actors, resting did not work - confirming the rest dialog resulted in no changes and a error message in the console about this line trying to access `.onRest` on undefined, presumably on items on the actor which did not have `uses` defined.

After this change, that actor is indeed able to rest, and to regain spent spells as intended.