### PR TITLE
Fix initiative warning, only prompt players

### DIFF
--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -386,7 +386,9 @@ export default class WWCombat extends Combat {
     if (options.direction === 1 && data.round) {
 
       if (!game.user.character) {
-        ui.notifications.warn(i18n('WW.Combat.TakingInit.NoCharacter'));
+        if (!game.user.isGM) {
+          ui.notifications.warn(i18n('WW.Combat.Initiative.NoCharacter'));
+        }
       } else {
 
         const confirm = await Dialog.confirm({


### PR DESCRIPTION
This fixes the translation string for the "You have no character assigned" warning on new rounds, and also only displays that warning for non-GMs (i.e., players).