### PR TITLE
Add "Show Image" / "Show Token" menu to PC and NPC sheets

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -712,7 +712,10 @@
 "WW.System.Dialog.Reset": "Reset",
 "WW.System.Dialog.Cancel": "Cancel",
 
-"WW.System.EditImage": "Click to edit image",
+"WW.System.Image.Edit": "Click to edit image.",
+"WW.System.Image.EditShow": "Click to edit image. Right click to show and share image.",
+"WW.System.Image.Show": "Show Image",
+"WW.System.Image.ShowToken": "Show Token",
 
 "WW.System.Migration.Started": "Outdated data found. Please wait until the data migration is finished.",
 "WW.System.Migration.Forced": "Forced data migration started. Please wait until the data migration is finished.",

--- a/module/helpers/templates.mjs
+++ b/module/helpers/templates.mjs
@@ -5,8 +5,9 @@
  */
  export const preloadHandlebarsTemplates = async function() {
   return loadTemplates([
-
     // Actor partials
+    "systems/weirdwizard/templates/actors/parts/portrait.hbs",
+
     // Character
     "systems/weirdwizard/templates/actors/parts/Character-summary.hbs",
     "systems/weirdwizard/templates/actors/parts/Character-summary-item.hbs",

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -375,6 +375,35 @@ export default class WWActorSheet extends ActorSheet {
   activateListeners(html) {
     super.activateListeners(html);
 
+    let actor = this.actor;
+
+    // Toggle portrait menu on right mouse button
+    let profileImg = html.find(".profile-img");
+    let profileImgMenu = html.find(".profile-menu");
+    let profileImgButton = html.find(".profile-show");
+    profileImg.mousedown(async (e) => {
+      if (e.which === 3) profileImgMenu.toggleClass("hidden");
+    });
+    profileImgButton.mousedown(async (e) => {
+      if (e.which === 3) profileImgMenu.toggleClass("hidden");
+    });
+
+    // Handle portrait menu sharing buttons
+    profileImgButton.click(function (e) {
+      e.preventDefault();
+      profileImgMenu.addClass("hidden");
+      let id = $(this).attr("id");
+      let img = actor.img;
+      if (id == "showToken") {
+        img = actor.prototypeToken.texture.src;
+      }
+      new ImagePopout(img, {
+        title: game.weirdwizard.utils.getAlias({actor: actor}),
+        shareable: true,
+        uuid: actor.uuid,
+      }).render(true);
+    });
+
     // -------------------------------------------------------------
     // Everything below here is only needed if the sheet is editable
     if (!this.isEditable) return;

--- a/styles/weirdwizard.css
+++ b/styles/weirdwizard.css
@@ -404,6 +404,7 @@
 .weirdwizard.npc .profile-img-wrapper {
   flex: 0 0 var(--avatar-size-npc);
   height: var(--avatar-size-npc);
+  position: relative;
 }
 
 .weirdwizard.npc header.sheet-header img {
@@ -1675,6 +1676,29 @@ input[type="checkbox"].checkbox-uses {
 
 .weirdwizard .list-entries > div > span {
   display: inline-block;
+}
+
+.weirdwizard .profile-menu {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  white-space: nowrap;
+  display: none;
+}
+
+.weirdwizard .profile-menu:not(.hidden) {
+  display: flex;
+  flex-direction: column;
+}
+
+.weirdwizard .profile-menu .profile-show {
+  background: var(--background);
+  margin: 2px 0;
+  padding: 4px 6px;
+  border: 1px solid var(--purple-dark);
+  border-radius: 5px;
+  text-align: center;
 }
 
 /* Tooltips Customization */

--- a/templates/actors/Character-sheet.hbs
+++ b/templates/actors/Character-sheet.hbs
@@ -16,7 +16,7 @@
             </div>
 
             <div class="circle" style="--total: 4">
-                <img class="profile-img" src="{{actor.img}}" data-edit="img" data-tooltip="WW.System.EditImage" height="100" width="100"/>
+                {{> "systems/weirdwizard/templates/actors/parts/portrait.hbs" img=actor.img token=true}}
                 
                 <div class="stat" style="--i:1">
                     <label class="resource-label">{{localize "WW.Attributes.StrengthShort"}}</label>

--- a/templates/actors/NPC-sheet.hbs
+++ b/templates/actors/NPC-sheet.hbs
@@ -4,10 +4,7 @@
     <header class="sheet-header">
 
         <div class="profile-img-wrapper">
-            
-            {{!-- Profile Image --}}
-            <img class="profile-img" src="{{actor.img}}" data-edit="img" data-tooltip="WW.System.EditImage"/>
-
+            {{> "systems/weirdwizard/templates/actors/parts/portrait.hbs" img=actor.img token=true}}
         </div>
 
         <div class="header-fields">

--- a/templates/actors/parts/Character-equipment.hbs
+++ b/templates/actors/parts/Character-equipment.hbs
@@ -71,7 +71,7 @@
         {{#each weapons as |item id|}}
         <li class="item flexrow flex-group-left" data-item-id="{{item._id}}">
             {{!-- Icon --}}
-            <div class="item-image"><img src="{{item.img}}" data-tooltip="WW.System.EditImage" width="24" height="24" /></div>
+            <div class="item-image"><img src="{{item.img}}" data-tooltip="{{item.name}}" width="24" height="24" /></div>
 
             <div class="item-name">
                 {{!-- Title --}}
@@ -149,7 +149,7 @@
         {{#each equipment as |item id|}}
         <li class="item flexrow" data-item-id="{{item._id}}">
             {{!-- Icon --}}
-            <div class="item-image"><img src="{{item.img}}" data-tooltip="WW.System.EditImage" width="24" height="24" /></div>
+            <div class="item-image"><img src="{{item.img}}" data-tooltip="{{item.name}}" width="24" height="24" /></div>
 
             {{!-- Quantity --}}
             <div class="item-quantity">{{item.system.quantity}}</div>

--- a/templates/actors/parts/Character-spells.hbs
+++ b/templates/actors/parts/Character-spells.hbs
@@ -41,7 +41,7 @@
     <li class="item flexrow" data-item-id="{{item._id}}">
 
         {{!-- Icon --}}
-        <div class="item-image"><img src="{{item.img}}" data-tooltip="WW.System.EditImage" width="24" height="24" /></div>
+        <div class="item-image"><img src="{{item.img}}" data-tooltip="{{item.name}}" width="24" height="24" /></div>
 
         <div class="item-name">
             

--- a/templates/actors/parts/Character-talents.hbs
+++ b/templates/actors/parts/Character-talents.hbs
@@ -15,7 +15,7 @@
     <li class="item flexrow" data-item-id="{{item._id}}">
 
         {{!-- Icon --}}
-        <div class="item-image"><img src="{{item.img}}" data-tooltip="WW.System.EditImage" width="24" height="24" /></div>
+        <div class="item-image"><img src="{{item.img}}" data-tooltip="{{item.name}}" width="24" height="24" /></div>
         
         <div class="item-name">
             {{!-- Title --}}

--- a/templates/actors/parts/portrait.hbs
+++ b/templates/actors/parts/portrait.hbs
@@ -1,0 +1,8 @@
+<img class="profile-img" src="{{img}}" data-edit="img"
+data-tooltip="WW.System.Image.EditShow" />
+<div class="profile-menu hidden">
+  <a class="profile-show" id="showPortrait">{{localize 'WW.System.Image.Show'}}</a>
+  {{#if token}}
+  <a class="profile-show" id="showToken">{{localize 'WW.System.Image.ShowToken'}}</a>
+  {{/if}}
+</div>

--- a/templates/items/Equipment-sheet.hbs
+++ b/templates/items/Equipment-sheet.hbs
@@ -2,7 +2,7 @@
 
   {{!-- Header --}}
   <header class="sheet-header">
-    <img class="profile-img" src="{{item.img}}" data-edit="img" data-tooltip="WW.System.EditImage"/>
+    <img class="profile-img" src="{{item.img}}" data-edit="img" data-tooltip="WW.System.Image.Edit"/>
 
     <div class="header-fields">
       <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize "WW.Item.Name"}}"/></h1>

--- a/templates/items/Spell-sheet.hbs
+++ b/templates/items/Spell-sheet.hbs
@@ -2,7 +2,7 @@
 
   {{!-- Header --}}
   <header class="sheet-header">
-    <img class="profile-img" src="{{item.img}}" data-edit="img" data-tooltip="WW.System.EditImage" />
+    <img class="profile-img" src="{{item.img}}" data-edit="img" data-tooltip="WW.System.Image.Edit" />
     <div class="header-fields">
       <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize "WW.Item.Name"}}" /></h1>
 

--- a/templates/items/Trait or Talent-sheet.hbs
+++ b/templates/items/Trait or Talent-sheet.hbs
@@ -2,7 +2,7 @@
 
   {{!-- Header --}}
   <header class="sheet-header">
-    <img class="profile-img" src="{{item.img}}" data-edit="img" data-tooltip="WW.System.EditImage" />
+    <img class="profile-img" src="{{item.img}}" data-edit="img" data-tooltip="WW.System.Image.Edit" />
     <div class="header-fields">
       <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize "WW.Item.Name"}}" /></h1>
 

--- a/templates/items/ancestry-sheet.hbs
+++ b/templates/items/ancestry-sheet.hbs
@@ -7,7 +7,7 @@
 
       {{!-- Header --}}
       <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" data-tooltip="WW.System.EditImage"/>
+        <img class="profile-img" src="{{item.img}}" data-edit="img" data-tooltip="WW.System.Image.Edit"/>
         <div class="header-fields">
           <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize "WW.Item.Name"}}"/></h1>
 

--- a/templates/items/path-sheet.hbs
+++ b/templates/items/path-sheet.hbs
@@ -7,7 +7,7 @@
 
       {{!-- Header --}}
       <header class="sheet-header">
-        <img class="profile-img" src="{{item.img}}" data-edit="img" data-tooltip="WW.System.EditImage"/>
+        <img class="profile-img" src="{{item.img}}" data-edit="img" data-tooltip="WW.System.Image.Edit"/>
         <div class="header-fields">
           <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize "WW.Item.Name"}}"/></h1>
 

--- a/templates/items/profession-sheet.hbs
+++ b/templates/items/profession-sheet.hbs
@@ -2,7 +2,7 @@
 
   {{!-- Header --}}
   <header class="sheet-header">
-    <img class="profile-img" src="{{item.img}}" data-edit="img" data-tooltip="WW.System.EditImage" />
+    <img class="profile-img" src="{{item.img}}" data-edit="img" data-tooltip="WW.System.Image.Edit" />
     <div class="header-fields">
       <h1 class="charname"><input name="name" type="text" value="{{item.name}}" placeholder="{{localize "WW.Item.Name"}}" /></h1>
   


### PR DESCRIPTION
This adds a right-click menu to PC and NPC profile images to show the actor image or token image in a larger popup, which also comes with share options to show the image to players, similar to how Tidy5E and other sheets in other systems do it.

![show](https://github.com/Savantford/foundry-weirdwizard/assets/1654763/faa61142-b899-4c3b-b502-6a95280f09aa)

Also fixes 4 tooltips in character item sheet sections.

Closes https://github.com/Savantford/foundry-weirdwizard/issues/164