### PR TITLE
Improve NPC disposition toggle

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -14,7 +14,10 @@
 
 "WW.Actor.Disposition.Enemy": "Enemy",
 "WW.Actor.Disposition.Ally": "Ally",
-"WW.Actor.Disposition.Tip": "Click to change disposition.",
+"WW.Actor.Disposition.Neutral": "Neutral",
+"WW.Actor.Disposition.Secret": "Secret",
+"WW.Actor.Disposition.Unknown": "Unknown",
+"WW.Actor.Disposition.Tip": "<p>Click to toggle disposition between <b>Ally</b> (<i>friendly</i>) and <b>Enemy</b> (<i>hostile</i>).</p><p>In <i>Shadow of the Weird Wizard</i>, a creature is either an enemy or an ally for the purpose of combat.</p><p>Foundry's <i>neutral</i> disposition should not be used. Use <b>Enemy</b> (<i>hostile</i>) for unaligned creatures or <b>Ally</b> (<i>friendly</i>) if they are actively helping the characters.</p><p>Foundry's <i>secret</i> disposition should be used wisely. You should switch the disposition to <b>Enemy</b> or <b>Ally</b> before combat begins.</p>",
 
 "WW.Attributes.Label": "Attributes",
 "WW.Attributes.Strength": "Strength",

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -854,32 +854,26 @@ export default class WWActorSheet extends ActorSheet {
     ChatMessage.create(messageData);
   }
 
-  _onDispositionChange() {
+  async _onDispositionChange() {
+    // Toggle disposition between friendly and hostile, updating all linked tokens.
     const dispo = this.actor?.token ? this.actor.token.disposition : this.actor.prototypeToken.disposition;
     const linkedTokens = this.actor.getActiveTokens();
+
+    let newDispo = CONST.TOKEN_DISPOSITIONS.FRIENDLY;
+    if (dispo === CONST.TOKEN_DISPOSITIONS.FRIENDLY) {
+      newDispo = CONST.TOKEN_DISPOSITIONS.HOSTILE;
+    }
     
-    if (dispo === -1) {
-      
-      this.actor.update({
-        'prototypeToken.disposition': 1,
-        'token.disposition': 1
-      })
+    await this.actor.update({
+      'prototypeToken.disposition': newDispo,
+      'token.disposition': newDispo
+    })
 
-      linkedTokens.forEach(t => t.document.disposition = 1)
-
-      this.render();
-    } else {
-      
-      this.actor.update({
-        'prototypeToken.disposition': -1,
-        'token.disposition': -1
-      })
-
-      linkedTokens.forEach(t => t.document.disposition = -1)
-
-      this.render();
+    for await (const t of linkedTokens) {
+      await t.document.update({'disposition': newDispo});
     }
 
+    this.render();
   }
 
   /* -------------------------------------------- */

--- a/templates/actors/NPC-sheet.hbs
+++ b/templates/actors/NPC-sheet.hbs
@@ -17,8 +17,13 @@
                 <h1 class="charname"><input name="name" type="text" value="{{actor.name}}" placeholder="{{localize "WW.Actor.Name"}}"/></h1>
 
                 {{!-- Disposition Toggle --}}
-                <a class="change-disposition{{#if (eq disposition 1)}} ally{{/if}}" data-tooltip="WW.Actor.Disposition.Tip">
-                    {{#if (eq disposition 1)}}{{localize "WW.Actor.Disposition.Ally"}}{{else}}{{localize "WW.Actor.Disposition.Enemy"}}{{/if}}
+                <a class="change-disposition{{#if (eq disposition 1)}} ally{{else if (eq disposition -1)}} enemy{{/if}}"
+                    data-tooltip="WW.Actor.Disposition.Tip">
+                    {{#if (eq disposition 1)}}{{localize "WW.Actor.Disposition.Ally"}}
+                    {{else if (eq disposition -1)}}{{localize "WW.Actor.Disposition.Enemy"}}
+                    {{else if (eq disposition 0)}}{{localize "WW.Actor.Disposition.Neutral"}} (!)
+                    {{else if (eq disposition -2)}}{{localize "WW.Actor.Disposition.Secret"}} (!)
+                    {{else}}{{localize "WW.Actor.Disposition.Unknown"}} (!){{/if}}
                 </a>
                 
             </div>


### PR DESCRIPTION
This improves the disposition toggle on the NPC sheet in the following ways:

- The tooltip now explains dispositions, and that Foundry's **Neutral** and **Secret** dispositions should not be used (or only used with care)
- The toggle is now able to display all dispositions, and highlights non-recommended dispositions (like **Neutral** and **Secret**) in a warning yellow, and with an appended `(!)`
- Linked tokens are now properly updated
- A race condition was fixed, where the sheet could be re-rendered before updating the data finished, resulting in the sheet mistakenly showing the previous disposition

![disposition](https://github.com/Savantford/foundry-weirdwizard/assets/1654763/cfbcaab9-919c-45e3-ab78-89e6c39d1129)
