### PR TITLE
Swap back Intellect and Will to traditional order

### DIFF
--- a/templates/actors/Character-sheet.hbs
+++ b/templates/actors/Character-sheet.hbs
@@ -45,14 +45,14 @@
 
                 </div>
 
-                <div class="stat int" style="--i:6">
-                    <label><a class="item-button" data-action="attribute-roll" data-key="int" data-tooltip="WW.Roll.Intellect">{{localize "WW.Attributes.IntellectShort"}}</a></label>
-
+                <div class="stat wil" style="--i:6">
+                    <label><a class="item-button" data-action="attribute-roll" data-key="wil" data-tooltip="WW.Roll.Will">{{localize "WW.Attributes.WillShort"}}</a></label>
+                    
                     <div>
-                        <input type="number" name="system.attributes.int.value" value="{{system.attributes.int.value}}" min="0" data-dtype="Number"/>
-                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="int" data-tooltip="WW.Roll.Intellect">
-                            {{#if system.attributes.int.value}}
-                            {{numberFormat system.attributes.int.mod decimals=0 sign=true}}
+                        <input type="number" name="system.attributes.wil.value" value="{{system.attributes.wil.value}}" min="0" data-dtype="Number"/>
+                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="wil" data-tooltip="WW.Roll.Will">
+                            {{#if system.attributes.wil.value}}
+                            {{numberFormat system.attributes.wil.mod decimals=0 sign=true}}
                             {{else}}—{{/if}}
                         </a>
                     </div>
@@ -62,14 +62,14 @@
                     <label><a class="item-button" data-action="attribute-roll" data-key="luck" data-tooltip="WW.Roll.Luck">{{localize "WW.Attributes.Luck"}}</a></label>
                 </div>
 
-                <div class="stat wil" style="--i:8">
-                    <label><a class="item-button" data-action="attribute-roll" data-key="wil" data-tooltip="WW.Roll.Will">{{localize "WW.Attributes.WillShort"}}</a></label>
-                    
+                <div class="stat int" style="--i:8">
+                    <label><a class="item-button" data-action="attribute-roll" data-key="int" data-tooltip="WW.Roll.Intellect">{{localize "WW.Attributes.IntellectShort"}}</a></label>
+
                     <div>
-                        <input type="number" name="system.attributes.wil.value" value="{{system.attributes.wil.value}}" min="0" data-dtype="Number"/>
-                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="wil" data-tooltip="WW.Roll.Will">
-                            {{#if system.attributes.wil.value}}
-                            {{numberFormat system.attributes.wil.mod decimals=0 sign=true}}
+                        <input type="number" name="system.attributes.int.value" value="{{system.attributes.int.value}}" min="0" data-dtype="Number"/>
+                        <a class="attribute-mod item-button" data-action="attribute-roll" data-key="int" data-tooltip="WW.Roll.Intellect">
+                            {{#if system.attributes.int.value}}
+                            {{numberFormat system.attributes.int.mod decimals=0 sign=true}}
                             {{else}}—{{/if}}
                         </a>
                     </div>


### PR DESCRIPTION
Swap back Intellect and Will from the recent update to match "traditional" ordering from the corebook again,