### PR TITLE
Add Target/Duration header to spell tooltips

### DIFF
--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -104,20 +104,44 @@ export default class WWActorSheet extends ActorSheet {
     // Prepare effect change labels to display
     context.effectChangeLabels = CONFIG.WW.EFFECT_CHANGE_LABELS;
 
+    // Setup usage help text for tooltips
+    var usagehelp = escape(`
+      <hr>
+      <p>${i18n("WW.Item.Perform.Left")}</p>
+      <p>${i18n("WW.Item.Perform.Shift")}</p>
+      <p>${i18n("WW.Item.Perform.Ctrl")}</p>
+      <p>${i18n("WW.Item.Perform.Alt")}</p>
+      <p>${i18n("WW.Item.Perform.Right")}</p>
+    `);
+
     // Prepare item html fields
     for (let i of context.items) {
       i.system.description.enriched = await TextEditor.enrichHTML(i.system.description.value, { async: true })
       if (i.system.attackRider) i.system.attackRider.enriched = await TextEditor.enrichHTML(i.system.attackRider?.value, { async: true })
 
-      // Prepare tooltips
-      i.tooltip = await escape(`
-        ${i.system.description.enriched}<hr>
-        <p>${i18n("WW.Item.Perform.Left")}</p>
-        <p>${i18n("WW.Item.Perform.Shift")}</p>
-        <p>${i18n("WW.Item.Perform.Ctrl")}</p>
-        <p>${i18n("WW.Item.Perform.Alt")}</p>
-        <p>${i18n("WW.Item.Perform.Right")}</p>
-      `);
+      var descriptor = '';
+
+      // Prepare tooltips by type
+      switch(i.type) {
+
+        // Formatting for spells
+        case 'Spell':
+          descriptor = await escape(`
+            <b>${i18n("WW.Spell.Target")}:</b> ${i.system.target}<br>
+            <b>${i18n("WW.Spell.Duration")}:</b> ${i.system.duration}<hr>
+            ${i.system.description.enriched}
+          `);
+          break;
+
+        // Formatting for everything else
+        default:
+          descriptor = await escape(`
+            ${i.system.description.enriched}
+          `);
+      }
+
+      // Append general usage help text
+      i.tooltip = descriptor + usagehelp;
     }
 
     // Prepare Disposition

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -104,8 +104,8 @@ export default class WWActorSheet extends ActorSheet {
     // Prepare effect change labels to display
     context.effectChangeLabels = CONFIG.WW.EFFECT_CHANGE_LABELS;
 
-    // Setup usage help text for tooltips
-    var usagehelp = escape(`
+    // Setup usage help text for tooltips (so we can reuse it)
+    const usagehelp = escape(`
       <hr>
       <p>${i18n("WW.Item.Perform.Left")}</p>
       <p>${i18n("WW.Item.Perform.Shift")}</p>
@@ -119,16 +119,17 @@ export default class WWActorSheet extends ActorSheet {
       i.system.description.enriched = await TextEditor.enrichHTML(i.system.description.value, { async: true })
       if (i.system.attackRider) i.system.attackRider.enriched = await TextEditor.enrichHTML(i.system.attackRider?.value, { async: true })
 
-      var descriptor = '';
+      // empty description, so we can fill it with type specific content
+      let descriptor = '';
 
-      // Prepare tooltips by type
+      // Form description based on type
       switch(i.type) {
 
-        // Formatting for spells
+        // Formatting for Spells
         case 'Spell':
           descriptor = await escape(`
-            <b>${i18n("WW.Spell.Target")}:</b> ${i.system.target}<br>
-            <b>${i18n("WW.Spell.Duration")}:</b> ${i.system.duration}<hr>
+            <p><b>${i18n("WW.Spell.Target")}:</b> ${i.system.target}</p>
+            <p><b>${i18n("WW.Spell.Duration")}:</b> ${i.system.duration}</p>
             ${i.system.description.enriched}
           `);
           break;
@@ -140,7 +141,7 @@ export default class WWActorSheet extends ActorSheet {
           `);
       }
 
-      // Append general usage help text
+      // Create tooltip from concat of description and usage help text
       i.tooltip = descriptor + usagehelp;
     }
 

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -128,8 +128,8 @@ export default class WWActorSheet extends ActorSheet {
         // Formatting for Spells
         case 'Spell':
           descriptor = await escape(`
-            <p><b>${i18n("WW.Spell.Target")}:</b> ${i.system.target}</p>
-            <p><b>${i18n("WW.Spell.Duration")}:</b> ${i.system.duration}</p>
+            <p><b>${i18n("WW.Spell.Target")}:</b> ${i.system.target}<br>
+            <b>${i18n("WW.Spell.Duration")}:</b> ${i.system.duration}</p>
             ${i.system.description.enriched}
           `);
           break;


### PR DESCRIPTION
Extends tooltips to check for activity type when being formed. This allows modifying the text strings based on the type; this allows the inclusion of spell-specific information (target, duration) to the tooltip to better usability:
![image](https://github.com/Savantford/foundry-weirdwizard/assets/7926955/04e18d80-7dda-4726-b637-f5e37cbf371e)

To make future changes easier, the usage help text has been separated out, so it can be appended to any tooltip formed this way without duplicating the text over and over - this should make future extension of tooltips (if desired) pretty straightforward.