### PR TITLE
Adjusted health/damage checks on health adjustment

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -94,7 +94,8 @@ export default class WWActor extends Actor {
       const cDamage = cStats.damage?.value;
       
       // Set incapactated status
-      if (cDamage >= await health || await cHealth >= await damage) this.incapacitated = true; else this.incapacitated = false;
+      if (cDamage >= await health || await cHealth <= await damage || await health == await damage) this.incapacitated = true; else this.incapacitated = false;
+      if (await cDamage < await damage) this.incapacitated = false;
     }
     
     // Update token status icons


### PR DESCRIPTION
Current algorithm will always set damage equal to health when health is adjusted, due to flipped comparison between `cHealth` and `damage`, this fix corrects the bug.

Additionally, the case of `health == damage` is included (to correctly trigger the health adjustment when health is increased). To allow exiting the incapacitated status, the specific case of new damage being less than the current damage is checked for, to clear incapacitated.