### PR TITLE
Add functionality for Uses/Charges to be relative to character level.

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -216,7 +216,7 @@
 "WW.Item.Uses.ActionRecover": "Recover use/casting/token",
 
 "WW.Item.Uses.OnRest": "Recover on rest?",
-"WW.Item.Uses.LevelRelative": "Is the uses/charges relative to the owner's level?",
+"WW.Item.Uses.LevelRelative": "Is the uses/charges relative to the owner's level? Only applicable for player characters.",
 
 "WW.Talent.Uses.None": "Not Relative",
 "WW.Talent.Uses.Half": "Equal to Level",

--- a/lang/en.json
+++ b/lang/en.json
@@ -216,6 +216,11 @@
 "WW.Item.Uses.ActionRecover": "Recover use/casting/token",
 
 "WW.Item.Uses.OnRest": "Recover on rest?",
+"WW.Item.Uses.LevelRelative": "Is the uses/charges relative to the owner's level?",
+
+"WW.Talent.Uses.None": "Not Relative",
+"WW.Talent.Uses.Half": "Equal to Level",
+"WW.Talent.Uses.Full": "Equal to Half Level",
 
 "WW.Roll.Label": "Roll",
 "WW.Roll.Settings": "Roll Settings",

--- a/lang/en.json
+++ b/lang/en.json
@@ -219,8 +219,8 @@
 "WW.Item.Uses.LevelRelative": "Is the uses/charges relative to the owner's level? Only applicable for player characters.",
 
 "WW.Item.Uses.None": "Not Relative",
-"WW.Item.Uses.Half": "Equal to Level",
-"WW.Item.Uses.Full": "Equal to Half Level",
+"WW.Item.Uses.Half": "Equal to Half Level",
+"WW.Item.Uses.Full": "Equal to Level",
 
 "WW.Roll.Label": "Roll",
 "WW.Roll.Settings": "Roll Settings",

--- a/lang/en.json
+++ b/lang/en.json
@@ -218,9 +218,9 @@
 "WW.Item.Uses.OnRest": "Recover on rest?",
 "WW.Item.Uses.LevelRelative": "Is the uses/charges relative to the owner's level? Only applicable for player characters.",
 
-"WW.Talent.Uses.None": "Not Relative",
-"WW.Talent.Uses.Half": "Equal to Level",
-"WW.Talent.Uses.Full": "Equal to Half Level",
+"WW.Item.Uses.None": "Not Relative",
+"WW.Item.Uses.Half": "Equal to Level",
+"WW.Item.Uses.Full": "Equal to Half Level",
 
 "WW.Roll.Label": "Roll",
 "WW.Roll.Settings": "Roll Settings",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -93,9 +93,9 @@ WW.TALENT_SOURCES = {
 };
 
 WW.USES_LEVEL_RELATIVE = {
-  'manual': 'WW.Talent.Uses.None',
-  'full': 'WW.Talent.Uses.Full',
-  'half': 'WW.Talent.Uses.Half'
+  'manual': 'WW.Item.Uses.None',
+  'full': 'WW.Item.Uses.Full',
+  'half': 'WW.Item.Uses.Half'
 };
 
 WW.TIERS = {

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -92,6 +92,12 @@ WW.TALENT_SOURCES = {
   'Other': 'WW.Talent.Source.Other'
 };
 
+WW.USES_LEVEL_RELATIVE = {
+  'manual': 'WW.Talent.Uses.None',
+  'full': 'WW.Talent.Uses.Full',
+  'half': 'WW.Talent.Uses.Half'
+};
+
 WW.TIERS = {
   'Novice': 'WW.CharOptions.Novice',
   'Expert': 'WW.CharOptions.Expert',

--- a/module/data/items/common.mjs
+++ b/module/data/items/common.mjs
@@ -54,7 +54,8 @@ export function activity(type = String) {
     uses: new fields.SchemaField({
       value: makeIntField(),
       max: makeIntField(),
-      onRest: makeBooField(true)
+      onRest: makeBooField(true),
+      levelRelative: makeStrField('manual',0,1)
     }),
 
     healing: makeStrField(),

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -395,7 +395,14 @@ export default class WWActorSheet extends ActorSheet {
     // Prepare uses pips for talents and spells
     function updateUses(item, id) {
       let spent = item.system.uses.value ? item.system.uses.value : 0;
-      let max = item.system.uses.max;
+      let max = 0;
+      
+      switch (item.system.uses.levelRelative ) {
+        case 'manual': max = item.system.uses.max; break;
+        case 'full': max = context.actor.system.stats.level; break;
+        case 'half': max = Math.floor(context.actor.system.stats.level / 2); break;
+      }
+
       let arr = [];
 
       let i = 0; // fill the Buttons with available traditions

--- a/module/sheets/actor-sheet.mjs
+++ b/module/sheets/actor-sheet.mjs
@@ -395,12 +395,16 @@ export default class WWActorSheet extends ActorSheet {
     // Prepare uses pips for talents and spells
     function updateUses(item, id) {
       let spent = item.system.uses.value ? item.system.uses.value : 0;
-      let max = 0;
+      let max = item.system.uses.max;
       
-      switch (item.system.uses.levelRelative ) {
-        case 'manual': max = item.system.uses.max; break;
-        case 'full': max = context.actor.system.stats.level; break;
-        case 'half': max = Math.floor(context.actor.system.stats.level / 2); break;
+      //Read the current amount of charges from the set max, or to be relative to the actor's level depending on the setting.
+      //Only do this if it's a player character, as NPCs and non-characters do not have a level value to be relative to.
+      if(context.actor.type === 'Character')
+      {
+        switch (item.system.uses.levelRelative ) {
+          case 'full': max = context.actor.system.stats.level; break;
+          case 'half': max = Math.floor(context.actor.system.stats.level / 2); break;
+        }
       }
 
       let arr = [];

--- a/module/sheets/item-sheet.mjs
+++ b/module/sheets/item-sheet.mjs
@@ -94,6 +94,7 @@ export default class WWItemSheet extends ItemSheet {
       case 'Trait or Talent':
         context.subtypes = CONFIG.WW.TALENT_SUBTYPES;
         context.sources = CONFIG.WW.TALENT_SOURCES;
+        context.usesLevelRelative = CONFIG.WW.USES_LEVEL_RELATIVE;
       break;
 
       case 'Spell':

--- a/templates/items/parts/Talent-details.hbs
+++ b/templates/items/parts/Talent-details.hbs
@@ -21,6 +21,10 @@
         </div>
         
         <input class="checkbox-uses" type="checkbox" name="system.uses.onRest" {{checked system.uses.onRest}} data-tooltip="WW.Item.Uses.OnRest"/>
+
+        <select name="system.uses.levelRelative" data-tooltip="WW.Item.Uses.LevelRelative">
+            {{selectOptions usesLevelRelative selected=system.uses.levelRelative localize=true}}
+        </select>
     </div>
 
 </div>


### PR DESCRIPTION
Adds a dropdown next to items' Uses/Tokens field that allows the talent to have its uses relative to the owning character's level.

TODO
- Fix localization for the dropdown
- Grey out the Uses/Tokens field when the dropdown is not "Not Relative"
- Test to make sure that it doesn't break when items with uses/charges are on NPCs and other types of actors