### PR TITLE
Background colour blend for whispered/blind messages and rolls

### DIFF
--- a/styles/weirdwizard.css
+++ b/styles/weirdwizard.css
@@ -3517,6 +3517,16 @@ form.quest-calendar {
   background-position: center;
 }
 
+/* Chat Message Tint (Whisper/Blind) */
+.weirdwizard.chat-message.whisper {
+  background-color: #e9ebf8;
+  background-blend-mode: multiply;
+}
+.weirdwizard.chat-message.blind {
+  background-color: #f8eaf8;
+  background-blend-mode: multiply;
+}
+
 /* Chat Message Separators */
 .weirdwizard.chat-message .footer-sender::after {
   content: "";


### PR DESCRIPTION
Sets correct background blending and colours for blind and whispered/private/self rolls (thanks for @Savantford finding the correct blend function). Uses slightly more intense version of the default colours to work better with the WW parchment texture.

Example:
![image](https://github.com/user-attachments/assets/8c2de09f-4f16-4a2c-8f08-995b2bec834f)
