### PR TITLE
changed icon paths from absolute to relative to support hosting foundry with a routePrefix

### DIFF
--- a/module/canvas/token.mjs
+++ b/module/canvas/token.mjs
@@ -81,14 +81,14 @@ export default class WWToken extends foundry.canvas.placeables.Token {
     const tokenSize = canvas.grid.size * this.document.width;
     const iconSize = tokenSize / 5;
 
-    let texture = PIXI.Texture.from('/systems/weirdwizard/assets/icons/shattered-heart.svg');
+    let texture = PIXI.Texture.from('systems/weirdwizard/assets/icons/shattered-heart.svg');
     let tint = this.#drd;
 
     if (dead) {
-      texture = PIXI.Texture.from('/icons/svg/skull.svg');
+      texture = PIXI.Texture.from('icons/svg/skull.svg');
       tint = this.#blk;
     } else if (incapacitated) {
-      texture = PIXI.Texture.from('/systems/weirdwizard/assets/icons/cross-mark.svg');
+      texture = PIXI.Texture.from('systems/weirdwizard/assets/icons/cross-mark.svg');
       tint = this.#ddr;
     }
     
@@ -134,20 +134,20 @@ export default class WWToken extends foundry.canvas.placeables.Token {
     const tokenSize = canvas.grid.size * this.document.width;
     const iconSize = tokenSize / 5;
 
-    let texture = PIXI.Texture.from('/systems/weirdwizard/assets/icons/skull-shield.svg');
+    let texture = PIXI.Texture.from('systems/weirdwizard/assets/icons/skull-shield.svg');
     let tint = this.#drd;
 
     if (current) {
-      texture = PIXI.Texture.from('/systems/weirdwizard/assets/icons/pointy-sword.svg');
+      texture = PIXI.Texture.from('systems/weirdwizard/assets/icons/pointy-sword.svg');
       tint = this.#grn;
     } else if (acted) {
-      texture = PIXI.Texture.from('/systems/weirdwizard/assets/icons/hourglass.svg');
+      texture = PIXI.Texture.from('systems/weirdwizard/assets/icons/hourglass.svg');
       tint = this.#gry;
     } else if (takingInit) {
-      texture = PIXI.Texture.from('/systems/weirdwizard/assets/icons/reactions.svg');
+      texture = PIXI.Texture.from('systems/weirdwizard/assets/icons/reactions.svg');
       tint = this.#ylw;
     } else if (combatant.actor?.type === 'character' || (combatant.actor?.type == 'npc' && dispo === 1)) {
-      texture = PIXI.Texture.from('/systems/weirdwizard/assets/icons/heart-shield.svg');
+      texture = PIXI.Texture.from('systems/weirdwizard/assets/icons/heart-shield.svg');
       tint = this.#wht;
     }
     

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -24,11 +24,11 @@ WW.ATTRIBUTE_ROLLS = {
 }
 
 WW.ATTRIBUTE_ICONS = {
-  'str': '/systems/weirdwizard/assets/icons/biceps.svg',
-  'agi': '/systems/weirdwizard/assets/icons/agility.svg',
-  'int': '/systems/weirdwizard/assets/icons/open-book.svg',
-  'wil': '/systems/weirdwizard/assets/icons/burning-star.svg',
-  'luck': '/systems/weirdwizard/assets/icons/clover.svg',
+  'str': 'systems/weirdwizard/assets/icons/biceps.svg',
+  'agi': 'systems/weirdwizard/assets/icons/agility.svg',
+  'int': 'systems/weirdwizard/assets/icons/open-book.svg',
+  'wil': 'systems/weirdwizard/assets/icons/burning-star.svg',
+  'luck': 'systems/weirdwizard/assets/icons/clover.svg',
   'def': 'icons/svg/shield.svg'
 }
 

--- a/module/dice/roll-attribute.mjs
+++ b/module/dice/roll-attribute.mjs
@@ -199,7 +199,7 @@ export default class RollAttribute extends HandlebarsApplicationMixin(Applicatio
           img: tar.img,
           name: tar.name,
           boonsNo,
-          boonsIcon: '/systems/weirdwizard/assets/icons/' + boonsIcon + '.svg',
+          boonsIcon: 'systems/weirdwizard/assets/icons/' + boonsIcon + '.svg',
           boonsTip,
           againstNo: tar.againstNo,
           againstLabel,

--- a/module/helpers/afflictions.mjs
+++ b/module/helpers/afflictions.mjs
@@ -108,12 +108,12 @@ export class WWAfflictions {
     ));
 
     // Controlled
-    effectsDataList.push(_buildBaseAffliction('controlled', '/systems/weirdwizard/assets/icons/puppet.svg'));
+    effectsDataList.push(_buildBaseAffliction('controlled', 'systems/weirdwizard/assets/icons/puppet.svg'));
     
     // Cursed
     effectsDataList.push(_buildBaseAffliction(
       'cursed',
-      '/systems/weirdwizard/assets/icons/bleeding-eye.svg',
+      'systems/weirdwizard/assets/icons/bleeding-eye.svg',
       [ addEffect('banes.luck', 1, addPriority) ]
     ));
 
@@ -133,7 +133,7 @@ export class WWAfflictions {
     // Held
     effectsDataList.push(_buildBaseAffliction(
       'held',
-      '/systems/weirdwizard/assets/icons/manacles.svg',
+      'systems/weirdwizard/assets/icons/manacles.svg',
       [
         downgradeEffect('speed.override', 0, overridePriority),
         overrideEffect('autoSuccessAgainst.agi', true, addPriority),
@@ -144,7 +144,7 @@ export class WWAfflictions {
     effectsDataList.push(
       _buildBaseAffliction(
         'impairedStr',
-        '/systems/weirdwizard/assets/icons/biceps-impaired.svg',
+        'systems/weirdwizard/assets/icons/biceps-impaired.svg',
         [
           addEffect('banes.str', 1, addPriority),
           addEffect('boonsAgainst.str', 1, addPriority)
@@ -156,7 +156,7 @@ export class WWAfflictions {
     effectsDataList.push(
       _buildBaseAffliction(
         'impairedAgi',
-        '/systems/weirdwizard/assets/icons/agility-impaired.svg',
+        'systems/weirdwizard/assets/icons/agility-impaired.svg',
         [
           addEffect('banes.agi', 1, addPriority),
           addEffect('boonsAgainst.agi', 1, addPriority)
@@ -168,7 +168,7 @@ export class WWAfflictions {
     effectsDataList.push(
       _buildBaseAffliction(
         'impairedInt',
-        '/systems/weirdwizard/assets/icons/open-book-impaired.svg',
+        'systems/weirdwizard/assets/icons/open-book-impaired.svg',
         [
           addEffect('banes.int', 1, addPriority),
           addEffect('boonsAgainst.int', 1, addPriority)
@@ -180,7 +180,7 @@ export class WWAfflictions {
     effectsDataList.push(
       _buildBaseAffliction(
         'impairedWil',
-        '/systems/weirdwizard/assets/icons/burning-star-impaired.svg',
+        'systems/weirdwizard/assets/icons/burning-star-impaired.svg',
         [
           addEffect('banes.wil', 1, addPriority),
           addEffect('boonsAgainst.wil', 1, addPriority)
@@ -191,26 +191,26 @@ export class WWAfflictions {
     // On Fire
     effectsDataList.push(_buildBaseAffliction(
       'onFire',
-      '/systems/weirdwizard/assets/icons/flaming-claw.svg',
+      'systems/weirdwizard/assets/icons/flaming-claw.svg',
       []
     ));
 
     // Poisoned
     effectsDataList.push(_buildBaseAffliction(
       'poisoned',
-      '/systems/weirdwizard/assets/icons/poison.svg',
+      'systems/weirdwizard/assets/icons/poison.svg',
       [].concat(baneAllAttributes(1))
         .concat(againstAll(1))
     ));
 
     // Prone
-    effectsDataList.push(_buildBaseAffliction('prone', '/systems/weirdwizard/assets/icons/fallen.svg'));
+    effectsDataList.push(_buildBaseAffliction('prone', 'systems/weirdwizard/assets/icons/fallen.svg'));
 
     // Slowed
     effectsDataList.push(
       _buildBaseAffliction(
         'slowed',
-        '/systems/weirdwizard/assets/icons/snail.svg',
+        'systems/weirdwizard/assets/icons/snail.svg',
         [ downgradeEffect('speed.override', 2, overridePriority) ]
       ),
     );
@@ -249,14 +249,14 @@ export class WWAfflictions {
     // Vulnerable
     effectsDataList.push(_buildBaseAffliction(
       'vulnerable',
-      '/systems/weirdwizard/assets/icons/broken-shield.svg',
+      'systems/weirdwizard/assets/icons/broken-shield.svg',
       [].concat(againstAll(1))
     ));
 
     // Weakened
     effectsDataList.push(_buildBaseAffliction(
       'weakened',
-      '/systems/weirdwizard/assets/icons/back-pain.svg',
+      'systems/weirdwizard/assets/icons/back-pain.svg',
       [
         addEffect('banes.str', 1, addPriority),
         addEffect('banes.agi', 1, addPriority),

--- a/module/sheets/actors/character-sheet.mjs
+++ b/module/sheets/actors/character-sheet.mjs
@@ -62,7 +62,7 @@ export default class WWCharacterSheet extends WWCreatureSheet {
         {id: 'equipment', tooltip: 'WW.Equipment.Label', icon: 'systems/weirdwizard/assets/icons/backpack.svg', iconType: 'img'},
         {id: 'talents', tooltip: 'WW.Talents.Label', icon: 'systems/weirdwizard/assets/icons/skills.svg', iconType: 'img'},
         {id: 'spells', tooltip: 'WW.Spells.Label', icon: 'systems/weirdwizard/assets/icons/spell-book.svg', iconType: 'img'},
-        {id: 'effects', tooltip: 'WW.Effects.Label', iconType: 'img', icon: '/icons/svg/aura.svg', iconType: 'img'}
+        {id: 'effects', tooltip: 'WW.Effects.Label', iconType: 'img', icon: 'icons/svg/aura.svg', iconType: 'img'}
       ],
       initial: "summary",
       labelPrefix: "EFFECT.TABS"

--- a/module/sheets/actors/npc-sheet.mjs
+++ b/module/sheets/actors/npc-sheet.mjs
@@ -74,7 +74,7 @@ export default class WWNpcSheet extends WWCreatureSheet {
       tabs: [
         {id: 'summary', tooltip: 'WW.Actor.Summary', iconType: 'img', icon: 'systems/weirdwizard/assets/icons/diploma.svg'},
         {id: 'description', tooltip: 'WW.Item.Description', icon: 'systems/weirdwizard/assets/icons/scroll-quill.svg', iconType: 'img'},
-        {id: 'effects', tooltip: 'WW.Effects.Label', iconType: 'img', icon: '/icons/svg/aura.svg', iconType: 'img'}
+        {id: 'effects', tooltip: 'WW.Effects.Label', iconType: 'img', icon: 'icons/svg/aura.svg', iconType: 'img'}
       ],
       initial: "summary",
       labelPrefix: "EFFECT.TABS"

--- a/module/sidebar/chat-html-templates.mjs
+++ b/module/sidebar/chat-html-templates.mjs
@@ -47,37 +47,37 @@ export function chatMessageButton({action, value, effectUuid, originUuid, target
     }
     /* Apply Actions */
     case 'applyDamage': {
-      img = '/systems/weirdwizard/assets/icons/rough-wound-black.svg';
+      img = 'systems/weirdwizard/assets/icons/rough-wound-black.svg';
       loc += 'Damage';
       showNo = false;
       break;
     }
     case 'applyDamageHalf': {
-      img = '/systems/weirdwizard/assets/icons/slashed-shield-black.svg';
+      img = 'systems/weirdwizard/assets/icons/slashed-shield-black.svg';
       loc += 'Half';
       showNo = false;
       break;
     }
     case 'applyDamageDouble': {
-      img = '/systems/weirdwizard/assets/icons/cross-mark-black.svg';
+      img = 'systems/weirdwizard/assets/icons/cross-mark-black.svg';
       loc += 'Double';
       showNo = false;
       break;
     }
     case 'applyHealing': {
-      img = '/systems/weirdwizard/assets/icons/caduceus-black.svg';
+      img = 'systems/weirdwizard/assets/icons/caduceus-black.svg';
       loc += 'Healing';
       showNo = false;
       break;
     }
     case 'applyHealthLoss': {
-      img = '/systems/weirdwizard/assets/icons/health-decrease-black.svg';
+      img = 'systems/weirdwizard/assets/icons/health-decrease-black.svg';
       loc += 'LoseHealth';
       showNo = false;
       break;
     }
     case 'applyHealthRegain': {
-      img = '/systems/weirdwizard/assets/icons/health-increase-black.svg';
+      img = 'systems/weirdwizard/assets/icons/health-increase-black.svg';
       loc += 'RegainHealth';
       showNo = false;
       break;
@@ -180,37 +180,37 @@ export function dataFromLabel(label) {
     }
     /* Apply Actions */
     case 'applyDamage': {
-      data.img = '/systems/weirdwizard/assets/icons/rough-wound-black.svg';
+      data.img = 'systems/weirdwizard/assets/icons/rough-wound-black.svg';
       data.loc += 'Damage';
       data.showNo = false;
       break;
     }
     case 'applyDamageHalf': {
-      data.img = '/systems/weirdwizard/assets/icons/slashed-shield-black.svg';
+      data.img = 'systems/weirdwizard/assets/icons/slashed-shield-black.svg';
       data.loc += 'Half';
       data.showNo = false;
       break;
     }
     case 'applyDamageDouble': {
-      data.img = '/systems/weirdwizard/assets/icons/cross-mark-black.svg';
+      data.img = 'systems/weirdwizard/assets/icons/cross-mark-black.svg';
       data.loc += 'Double';
       data.showNo = false;
       break;
     }
     case 'applyHealing': {
-      data.img = '/systems/weirdwizard/assets/icons/caduceus-black.svg';
+      data.img = 'systems/weirdwizard/assets/icons/caduceus-black.svg';
       data.loc += 'Healing';
       data.showNo = false;
       break;
     }
     case 'applyHealthLoss': {
-      data.img = '/systems/weirdwizard/assets/icons/health-decrease-black.svg';
+      data.img = 'systems/weirdwizard/assets/icons/health-decrease-black.svg';
       data.loc += 'LoseHealth';
       data.showNo = false;
       break;
     }
     case 'applyHealthRegain': {
-      data.img = '/systems/weirdwizard/assets/icons/health-increase-black.svg';
+      data.img = 'systems/weirdwizard/assets/icons/health-increase-black.svg';
       data.loc += 'RegainHealth';
       data.showNo = false;
       break;

--- a/styles/weirdwizard.css
+++ b/styles/weirdwizard.css
@@ -1224,7 +1224,7 @@ body.theme-dark.application.weirdwizard .window-content {
     text-align: center;
     color: var(--purple-dark);
     font-weight: 600;
-    background: url(/systems/weirdwizard/assets/ui/badges/npc-attribute.svg) no-repeat;
+    background: url(/../assets/ui/badges/npc-attribute.svg) no-repeat;
     background-position: center;
     background-size: contain;
 
@@ -1282,7 +1282,7 @@ body.theme-dark.application.weirdwizard .window-content {
       justify-content: center;
       width: var(--stat-size);
       height: var(--stat-size);
-      background: url(/systems/weirdwizard/assets/ui/badges/octagonal.svg) no-repeat;
+      background: url(../assets/ui/badges/octagonal.svg) no-repeat;
       background-position: center;
       background-size: contain;
       color: var(--body-text-color);
@@ -2248,7 +2248,7 @@ body.theme-dark.application.weirdwizard .window-content {
   justify-content: center;
   width: var(--stat-size);
   height: var(--stat-size);
-  background: url(/systems/weirdwizard/assets/ui/badges/shield.svg) no-repeat;
+  background: url(../assets/ui/badges/shield.svg) no-repeat;
   background-position: center;
   background-size: contain;
   margin: 0;
@@ -2389,17 +2389,17 @@ body.theme-dark.application.weirdwizard .window-content {
   width: var(--stat-size);
   height: var(--stat-size);
   line-height: normal;
-  background: url(/systems/weirdwizard/assets/ui/badges/octagonal.svg) no-repeat;
+  background: url(../assets/ui/badges/octagonal.svg) no-repeat;
   background-position: center;
   background-size: contain;
 }
 
 .weirdwizard .character-stats .stat.defense > div {
-  background-image: url(/systems/weirdwizard/assets/ui/badges/shield.svg);
+  background-image: url(../assets/ui/badges/shield.svg);
 }
 
 .weirdwizard .character-stats .stat.bonus-damage > div {
-  background-image: url(/systems/weirdwizard/assets/ui/badges/spiked.svg);
+  background-image: url(../assets/ui/badges/spiked.svg);
   --stat-size: 55px;
 }
 
@@ -6314,7 +6314,7 @@ p {
 }
 
 .weirdwizard .dice-comparison > .rolled-number {
-  background: url(/icons/svg/d20-grey.svg);
+  background: url(../../../icons/svg/d20-grey.svg);
 }
 
 .weirdwizard .dice-comparison > .target-number {


### PR DESCRIPTION
Update icon paths to support Foundry route prefixes.

This allows installations using a routePrefix to resolve icon URLs correctly.

Previously, paths starting with / bypassed the route prefix and caused assets to be requested from the domain root instead of the Foundry route.