### PR TITLE
fix active effect keys being overwritten with empty value

### DIFF
--- a/module/sheets/configs/active-effect-config.mjs
+++ b/module/sheets/configs/active-effect-config.mjs
@@ -254,7 +254,7 @@ export default class WWActiveEffectConfig extends WWSheetMixin(foundry.applicati
 
     submitData.system.changes?.forEach((change, index) => {
       // Apply preset
-      if (change.preset !== effChanges[index]?.preset) {
+      if (change.preset) {
         // Pass preset data to the change
         submitData.system.changes[index] = {
           ...change,


### PR DESCRIPTION
Fixes an issue where submitting an active effect overwrites the existing data key with an empty string.

Creating a new active effect gets saved in three steps.

1. when you create a new change to an active effect
2. when you select a preset
3. when you click on submit

The bug occurred during Step 3. The system sent a request to save the data, but because the preset/key itself hadn't changed during that specific step, it was left out of the payload. This caused the backend to overwrite the existing, valid key with an empty string.

Deleting this condition could be the wrong approach to a solution, but I must confess that I am ignorant to its utility. If it was important please do tell so I can find a better solution.