### PR TITLE
Fix speed effects

### DIFF
--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -243,6 +243,26 @@ export default class WWActiveEffect extends WWDocumentMixin(foundry.documents.Ac
 
   /* -------------------------------------------- */
 
+  /** 
+   * @override 
+   * 
+   * treat an unset current value as "no baseline to compare against
+   * yet" and apply the incoming delta directly, then fall back to core's
+   * real comparison logic once a base value exists. 
+   * 
+   * */
+  static _applyChangeUpgrade(targetDoc, change, current, delta, changes) {
+    if (current === null || current === undefined) {
+      if (change.type === "upgrade" || change.type === "downgrade") {
+        changes[change.key] = delta;
+      }
+      return;
+    }
+    return super._applyChangeUpgrade(targetDoc, change, current, delta, changes);
+  }
+
+  /* -------------------------------------------- */
+
   get formattedDuration() {
     const { value, units, expiry, ... duration } = this.duration;
     

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -479,7 +479,7 @@ export default class WWActor extends WWDocumentMixin(foundry.documents.Actor) {
     speed.current = speed.halved ? Math.floor(adjusted / 2) : adjusted;
     
     // Override Speed
-    if (speed.override ?? speed.current !== speed.current) {
+    if (speed.override !== null && speed.override !== undefined) {
       speed.current = speed.override;
     }
   }

--- a/module/helpers/afflictions.mjs
+++ b/module/helpers/afflictions.mjs
@@ -258,7 +258,7 @@ const createChange = (preset, value, priority, type) => ({
   preset,
   value,
   priority,
-  phase: 'final',
+  phase: 'initial', //use initial so changes are considered during prepareDerivedData
   type
 })
 


### PR DESCRIPTION
Reverted affliction phase to initial
- `change.phase` controls whether the changes are made before or after `prepareDerivedData()`. Since our speed calculation are being done inside the `prepareDerivedData()` our afflictions need the phase `initial`

Allow speed to be overridden by 0
- the condition  ` if (speed.override ?? speed.current !== speed.current)` did not allow afflictions to reduce the speed to 0. 

Override _applyChangeUpgrade to handle comparison to uninitialized value
- there is a problem with the core _applyChangeUpgrade() where it will interpret null as a zero when comparing if a new value is a downgrade or not. This means we need to either initialize `speed.override` with some value or change the `_applyChangeUpgrade()` to always accept a new value if the current value is null. Because I couldn't find a way to initialize speed.override with speed.normal reliably, I opted for the `_applyChangeUpgrade()`